### PR TITLE
Change type on AWS::Route53::HostedZone Name

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Route53.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Route53.scala
@@ -85,7 +85,7 @@ object `AWS::Route53::RecordSet` extends DefaultJsonProtocol {
 
 case class `AWS::Route53::HostedZone`(
                                        name:                    String,
-                                       Name:                    String,
+                                       Name:                    Token[String],
                                        VPCs:                    Seq[HostedZoneVPC],
                                        HostedZoneConfig:        HostedZoneConfig,
                                        override val Condition:  Option[ConditionRef] = None


### PR DESCRIPTION
Use Token[String] instead of String so we can put Ref values there.

Originally submitted against master, resubmitting against develop.