### PR TITLE
Add UpdatePolicy support to AutoScalingGroup

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -156,6 +156,8 @@ object Token extends DefaultJsonProtocol {
   implicit def fromAny[R: JsonFormat](r: R): AnyToken[R] = AnyToken(r)
   implicit def fromOptionAny[R: JsonFormat](or: Option[R]): Option[AnyToken[R]] = or.map(r => Token.fromAny(r))
   implicit def fromString(s: String): StringToken = StringToken(s)
+  implicit def fromBoolean(s: Boolean): BooleanToken = BooleanToken(s)
+  implicit def fromInt(s: Int): IntToken = IntToken(s)
   implicit def fromFunction[R](f: AmazonFunctionCall[R]): FunctionCallToken[R] = FunctionCallToken[R](f)
   implicit def fromSome[R](oR: Some[R])(implicit ev1: R => Token[R]): Some[Token[R]] = oR.map(ev1).asInstanceOf[Some[Token[R]]]
   implicit def fromOption[R](oR: Option[R])(implicit ev1: R => Token[R]): Option[Token[R]] = oR.map(ev1)
@@ -170,6 +172,8 @@ object Token extends DefaultJsonProtocol {
       obj match {
         case a: AnyToken[R]          => a.value.toJson
         case s: StringToken          => s.value.toJson
+        case i: IntToken             => i.value.toJson
+        case b: BooleanToken         => b.value.toJson
         case s: UNSAFEToken[_]       => s.value.toJson
           // its OK to erase the return type of AmazonFunctionCalls b/c they are only used at compile time for checking
           // not for de/serialization logic or JSON representation
@@ -185,6 +189,8 @@ object Token extends DefaultJsonProtocol {
 }
 case class AnyToken[R : JsonFormat](value: R) extends Token[R]
 case class StringToken(value: String) extends Token[String]
+case class BooleanToken(value: Boolean) extends Token[Boolean]
+case class IntToken(value: Int) extends Token[Int]
 case class FunctionCallToken[R](call: AmazonFunctionCall[R]) extends Token[R]
 
 @deprecated("use ParameterRef or ResourceRef instead", "Feb 20 2015")

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -26,7 +26,6 @@ case class `AWS::AutoScaling::AutoScalingGroup`(
 }
 
 object `AWS::AutoScaling::AutoScalingGroup` extends DefaultJsonProtocol {
-  implicitly [JsonFormat[Option[Int]]]
   implicit val format: JsonFormat[`AWS::AutoScaling::AutoScalingGroup`] = jsonFormat13(`AWS::AutoScaling::AutoScalingGroup`.apply)
 }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -8,56 +8,82 @@ import spray.json._
  */
 
 case class `AWS::AutoScaling::AutoScalingGroup`(
-  name:                    String,
-  AvailabilityZones:       Seq[Token[String]],
-  LaunchConfigurationName: Token[ResourceRef[`AWS::AutoScaling::LaunchConfiguration`]],
-  MinSize:                 StringBackedInt,
-  MaxSize:                 StringBackedInt,
-  DesiredCapacity:         Token[Int],
-  HealthCheckType:         String,
-  VPCZoneIdentifier:       Seq[Token[ResourceRef[`AWS::EC2::Subnet`]]],
-  Tags:                    Seq[AmazonTag],
-  LoadBalancerNames:       Option[Seq[Token[ResourceRef[`AWS::ElasticLoadBalancing::LoadBalancer`]]]],
-  override val Condition: Option[ConditionRef] = None,
-  override val DependsOn : Option[Seq[String]] = None
-  ) extends Resource[`AWS::AutoScaling::AutoScalingGroup`]{
-
+    name:                    String,
+    AvailabilityZones:       Seq[Token[String]],
+    LaunchConfigurationName: Token[ResourceRef[`AWS::AutoScaling::LaunchConfiguration`]],
+    MinSize:                 StringBackedInt,
+    MaxSize:                 StringBackedInt,
+    DesiredCapacity:         Token[Int],
+    HealthCheckType:         String,
+    VPCZoneIdentifier:       Seq[Token[ResourceRef[`AWS::EC2::Subnet`]]],
+    Tags:                    Seq[AmazonTag],
+    LoadBalancerNames:       Option[Seq[Token[ResourceRef[`AWS::ElasticLoadBalancing::LoadBalancer`]]]],
+    UpdatePolicy:            Option[UpdatePolicy] = None,
+    override val Condition: Option[ConditionRef] = None,
+    override val DependsOn : Option[Seq[String]] = None)
+  extends Resource[`AWS::AutoScaling::AutoScalingGroup`]{
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
+
 object `AWS::AutoScaling::AutoScalingGroup` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::AutoScaling::AutoScalingGroup`] = jsonFormat12(`AWS::AutoScaling::AutoScalingGroup`.apply)
+  implicitly [JsonFormat[Option[Int]]]
+  implicit val format: JsonFormat[`AWS::AutoScaling::AutoScalingGroup`] = jsonFormat13(`AWS::AutoScaling::AutoScalingGroup`.apply)
 }
 
 case class `AWS::AutoScaling::LaunchConfiguration`(
-  name:               String,
-  ImageId:            Token[AMIId],
-  InstanceType:       Token[String],
-  KeyName:            Token[String],
-  SecurityGroups:     Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
-  UserData:           `Fn::Base64`,
-  IamInstanceProfile: Option[Token[ResourceRef[`AWS::IAM::InstanceProfile`]]] = None,
-  override val Condition: Option[ConditionRef] = None,
-  override val DependsOn : Option[Seq[String]] = None
-  ) extends Resource[`AWS::AutoScaling::LaunchConfiguration`]{
-
+    name:               String,
+    ImageId:            Token[AMIId],
+    InstanceType:       Token[String],
+    KeyName:            Token[String],
+    SecurityGroups:     Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
+    UserData:           `Fn::Base64`,
+    IamInstanceProfile: Option[Token[ResourceRef[`AWS::IAM::InstanceProfile`]]] = None,
+    override val Condition: Option[ConditionRef] = None,
+    override val DependsOn : Option[Seq[String]] = None)
+  extends Resource[`AWS::AutoScaling::LaunchConfiguration`]{
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
+
 object `AWS::AutoScaling::LaunchConfiguration` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::AutoScaling::LaunchConfiguration`] = jsonFormat9(`AWS::AutoScaling::LaunchConfiguration`.apply)
 }
 
 case class `AWS::AutoScaling::ScalingPolicy`(
-  name:                 String,
-  AdjustmentType:       String,
-  AutoScalingGroupName: Token[ResourceRef[`AWS::AutoScaling::AutoScalingGroup`]],
-  Cooldown:             Token[Int],
-  ScalingAdjustment:    String,
-  override val Condition: Option[ConditionRef] = None,
-  override val DependsOn : Option[Seq[String]] = None
-  ) extends Resource[`AWS::AutoScaling::ScalingPolicy`]{
-
+    name:                 String,
+    AdjustmentType:       String,
+    AutoScalingGroupName: Token[ResourceRef[`AWS::AutoScaling::AutoScalingGroup`]],
+    Cooldown:             Token[Int],
+    ScalingAdjustment:    String,
+    override val Condition: Option[ConditionRef] = None,
+    override val DependsOn : Option[Seq[String]] = None)
+  extends Resource[`AWS::AutoScaling::ScalingPolicy`]{
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
+
 object `AWS::AutoScaling::ScalingPolicy` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::AutoScaling::ScalingPolicy`] = jsonFormat7(`AWS::AutoScaling::ScalingPolicy`.apply)
+}
+
+case class UpdatePolicy(
+    AutoScalingScheduledAction: ScheduledAction,
+    AutoScalingRollingUpdate: AutoScalingRollingUpdate)
+object UpdatePolicy extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[UpdatePolicy] = jsonFormat2(UpdatePolicy.apply)
+}
+
+case class ScheduledAction(IgnoreUnmodifiedGroupSizeProperties: Token[Boolean])
+
+object ScheduledAction extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[ScheduledAction] = jsonFormat1(ScheduledAction.apply)
+}
+
+case class AutoScalingRollingUpdate(
+    MaxBatchSize: Option[Token[Int]] = None,
+    MinInstancesInService: Option[Token[Int]] = None,
+    PauseTime: Option[Token[String]] = None,
+    SuspendProcesses: Option[Seq[Token[String]]] = None,
+    WaitOnResourceSignals: Option[Token[Boolean]] = None)
+
+object AutoScalingRollingUpdate extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[AutoScalingRollingUpdate] = jsonFormat5(AutoScalingRollingUpdate.apply)
 }


### PR DESCRIPTION
Adds the an optional [UpdatePolicy](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html) for AWS::AutoScaling::AutoScalingGroup

It does not go under `Properties`, it is a separate section like `Metadata`, so I made some slight changes to the `Resource` code rather than add another bit of code that extends it.  Nothing else uses `UpdatePolicy` as far as I know, but it seemed like the logical place to put it.  I already used it in production, it seems to work so far.  When I changed the launch config, it replaced all my nodes with new ones automatically like it is supposed to.

Great work on this code, it is easy to use and extend!  By far the best solution I've seen for managing the templates.