### PR TITLE
added DependsOn to more resources and their builders

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -19,9 +19,9 @@ case class `AWS::AutoScaling::AutoScalingGroup`(
     Tags:                    Seq[AmazonTag],
     LoadBalancerNames:       Option[Seq[Token[ResourceRef[`AWS::ElasticLoadBalancing::LoadBalancer`]]]],
     UpdatePolicy:            Option[UpdatePolicy] = None,
-    override val Condition: Option[ConditionRef] = None,
-    override val DependsOn : Option[Seq[String]] = None)
-  extends Resource[`AWS::AutoScaling::AutoScalingGroup`]{
+    override val Condition:  Option[ConditionRef] = None,
+    override val DependsOn : Option[Seq[String]] = None
+) extends Resource[`AWS::AutoScaling::AutoScalingGroup`] {
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 
@@ -38,8 +38,8 @@ case class `AWS::AutoScaling::LaunchConfiguration`(
     UserData:           `Fn::Base64`,
     IamInstanceProfile: Option[Token[ResourceRef[`AWS::IAM::InstanceProfile`]]] = None,
     override val Condition: Option[ConditionRef] = None,
-    override val DependsOn : Option[Seq[String]] = None)
-  extends Resource[`AWS::AutoScaling::LaunchConfiguration`]{
+    override val DependsOn : Option[Seq[String]] = None
+) extends Resource[`AWS::AutoScaling::LaunchConfiguration`] {
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 
@@ -54,8 +54,8 @@ case class `AWS::AutoScaling::ScalingPolicy`(
     Cooldown:             Token[Int],
     ScalingAdjustment:    String,
     override val Condition: Option[ConditionRef] = None,
-    override val DependsOn : Option[Seq[String]] = None)
-  extends Resource[`AWS::AutoScaling::ScalingPolicy`]{
+    override val DependsOn : Option[Seq[String]] = None
+) extends Resource[`AWS::AutoScaling::ScalingPolicy`]{
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticLoadBalancing.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticLoadBalancing.scala
@@ -28,7 +28,8 @@ case class `AWS::ElasticLoadBalancing::LoadBalancer` private (
   SecurityGroups:            Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
   Subnets:                   Seq[Token[ResourceRef[`AWS::EC2::Subnet`]]],
   Tags:                      Seq[AmazonTag],
-  override val Condition:    Option[ConditionRef] = None
+  override val Condition:    Option[ConditionRef] = None,
+  override val DependsOn:    Option[Seq[String]]  = None
 ) extends Resource[`AWS::ElasticLoadBalancing::LoadBalancer`] {
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
@@ -73,7 +74,8 @@ object `AWS::ElasticLoadBalancing::LoadBalancer` extends DefaultJsonProtocol {
     Scheme:                    Option[ELBScheme]                                  = None,
     SecurityGroups:            Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]] = Seq.empty,
     Tags:                      Seq[AmazonTag]                                     = Seq.empty,
-    Condition:                 Option[ConditionRef]                               = None
+    Condition:                 Option[ConditionRef]                               = None,
+    DependsOn:                 Option[Seq[String]]                                = None
   ) = `AWS::ElasticLoadBalancing::LoadBalancer`(
     name = name,
     Listeners = Listeners,
@@ -92,7 +94,8 @@ object `AWS::ElasticLoadBalancing::LoadBalancer` extends DefaultJsonProtocol {
     SecurityGroups = SecurityGroups,
     Subnets = Subnets,
     Tags = Tags,
-    Condition = Condition
+    Condition = Condition,
+    DependsOn = DependsOn
   )
 
   /**
@@ -134,7 +137,8 @@ object `AWS::ElasticLoadBalancing::LoadBalancer` extends DefaultJsonProtocol {
     Policies:                  Seq[ELBPolicy]                                     = Seq.empty,
     SecurityGroups:            Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]] = Seq.empty,
     Tags:                      Seq[AmazonTag]                                     = Seq.empty,
-    Condition:                 Option[ConditionRef]                               = None
+    Condition:                 Option[ConditionRef]                               = None,
+    DependsOn:                 Option[Seq[String]]                                = None
   ) = `AWS::ElasticLoadBalancing::LoadBalancer`(
     name = name,
     Listeners = Listeners,
@@ -153,10 +157,11 @@ object `AWS::ElasticLoadBalancing::LoadBalancer` extends DefaultJsonProtocol {
     SecurityGroups = SecurityGroups,
     Subnets = Seq.empty,
     Tags = Tags,
-    Condition = Condition
+    Condition = Condition,
+    DependsOn = DependsOn
   )
 
-  implicit val format: JsonFormat[`AWS::ElasticLoadBalancing::LoadBalancer`] = jsonFormat18(`AWS::ElasticLoadBalancing::LoadBalancer`.apply)
+  implicit val format: JsonFormat[`AWS::ElasticLoadBalancing::LoadBalancer`] = jsonFormat19(`AWS::ElasticLoadBalancing::LoadBalancer`.apply)
 }
 
 case class ELBAccessLoggingPolicy(

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
@@ -39,7 +39,7 @@ object Resource extends DefaultJsonProtocol {
           "Properties" -> JsObject(raw.fields - "name" - "Metadata" - "UpdatePolicy" - "Condition" - "DependsOn"),
           "UpdatePolicy" -> raw.fields.getOrElse("UpdatePolicy", JsNull),
           "Condition" -> obj.Condition.map(_.toJson).getOrElse(JsNull),
-          "DependsOn" -> obj.DependsOn.map(dependencies => JsArray(dependencies.map(JsString(_)).toVector)).getOrElse(JsNull)
+          "DependsOn" -> obj.DependsOn.map(dependencies => JsArray(dependencies.map(_.toJson).toVector)).getOrElse(JsNull)
         ).filter(_._2 != JsNull)
 
         JsObject(outputFields)

--- a/src/test/resources/cloudformation-template-vpc-example.json
+++ b/src/test/resources/cloudformation-template-vpc-example.json
@@ -1165,7 +1165,8 @@
         "InstanceId":{
           "Ref":"JumpInstance"
         }
-      }
+      },
+      "DependsOn":[ "GatewayToInternet" ]
     },
     "NATSecurityGroup":{
       "Type":"AWS::EC2::SecurityGroup",
@@ -1385,7 +1386,8 @@
         "InstanceId":{
           "Ref":"NAT1Instance"
         }
-      }
+      },
+      "DependsOn":[ "GatewayToInternet" ]
     },
     "NAT2Instance":{
       "Type":"AWS::EC2::Instance",
@@ -1504,7 +1506,8 @@
         "InstanceId":{
           "Ref":"NAT2Instance"
         }
-      }
+      },
+      "DependsOn":[ "GatewayToInternet" ]
     },
     "RouterELBSecurityGroup":{
       "Type":"AWS::EC2::SecurityGroup",

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/CloudFormation_AT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/CloudFormation_AT.scala
@@ -414,6 +414,12 @@ object StaxTemplate {
     Tags = standardTags("igw", "Public")
   )
 
+  val gatewayAttachmentResource = `AWS::EC2::VPCGatewayAttachment`(
+    "GatewayToInternet",
+    VpcId = ResourceRef(vpcResource),
+    InternetGatewayId = ResourceRef(internetGatewayResource)
+  )
+
   val publicRouteTableResource = `AWS::EC2::RouteTable`(
     "PublicRouteTable1",
     VpcId = ResourceRef(vpcResource),
@@ -922,18 +928,21 @@ object StaxTemplate {
 
   private val jumpEIPResource = `AWS::EC2::EIP`(
     "JumpEIP",
+    DependsOn = Some(Seq(gatewayAttachmentResource.name)),
     Domain = "vpc",
     InstanceId = ResourceRef(jumpInstanceResource)
   )
 
   private val nat1EIPResource = `AWS::EC2::EIP`(
     "NAT1EIP",
+    DependsOn = Some(Seq(gatewayAttachmentResource.name)),
     Domain = "vpc",
     InstanceId = ResourceRef(nat1InstanceResource)
   )
 
   private val nat2EIPResource = `AWS::EC2::EIP`(
     "NAT2EIP",
+    DependsOn = Some(Seq(gatewayAttachmentResource.name)),
     Domain = "vpc",
     InstanceId = ResourceRef(nat2InstanceResource)
   )
@@ -1000,11 +1009,7 @@ object StaxTemplate {
       pubSubnet2,
       priSubnet2,
       internetGatewayResource,
-      `AWS::EC2::VPCGatewayAttachment`(
-                                        "GatewayToInternet",
-                                        VpcId = ResourceRef(vpcResource),
-                                        InternetGatewayId = ResourceRef(internetGatewayResource)
-                                        ),
+      gatewayAttachmentResource,
       publicRouteTableResource,
       publicRouteTableResource.withRoute("Public", 1, 1, gateway = Some(ResourceRef(internetGatewayResource))),
       privateRouteTable1Resource,


### PR DESCRIPTION
DependsOn is an `Option[Seq[String]]`, which has two drawbacks: Option is superfluous for Seq and it should actually be a Seq of ResourceRefs. Unfortunately, CloudFormation requires a list of strings. Also, I did not change the implementation of DependsOn, I just added it to a bunch of resource types and their builders.

We can revisit the backward-compatibility breaking changing to something like `Seq[ResourceRef[_]]` at a later date. There are significant type/JSON-serialization challenges to making that work. Plus, including DependsOn even when empty will bloat the template a bit.