### PR TITLE
Modeled Autoscaling EBS parameters

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -47,7 +47,7 @@ case class `AWS::AutoScaling::LaunchConfiguration`(
 object `AWS::AutoScaling::LaunchConfiguration` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::AutoScaling::LaunchConfiguration`] = jsonFormat10(`AWS::AutoScaling::LaunchConfiguration`.apply)
 }
-case class BlockDeviceMapping(
+case class BlockDeviceMapping private(
   DeviceName:   Token[String],
   Ebs:  Option[AutoScalingEBS] = None,
   NoDevice: Option[Token[Boolean]] = None,
@@ -55,6 +55,18 @@ case class BlockDeviceMapping(
 )
 object BlockDeviceMapping extends DefaultJsonProtocol {
   implicit val format: JsonFormat[BlockDeviceMapping] = jsonFormat4(BlockDeviceMapping.apply)
+
+  def ebs(
+           DeviceName:   Token[String],
+           Ebs:  AutoScalingEBS,
+           NoDevice: Option[Token[Boolean]] = None
+           ) = BlockDeviceMapping(DeviceName, Some(Ebs), NoDevice, None)
+
+  def virtual(
+           DeviceName:   Token[String],
+           VirtualName:  Token[String],
+           NoDevice: Option[Token[Boolean]] = None
+           ) = BlockDeviceMapping(DeviceName, None, NoDevice, Some(VirtualName))
 }
 
 case class AutoScalingEBS(

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -37,6 +37,7 @@ case class `AWS::AutoScaling::LaunchConfiguration`(
     SecurityGroups:     Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
     UserData:           `Fn::Base64`,
     IamInstanceProfile: Option[Token[ResourceRef[`AWS::IAM::InstanceProfile`]]] = None,
+    BlockDeviceMappings: Option[Seq[BlockDeviceMapping]] = None,
     override val Condition: Option[ConditionRef] = None,
     override val DependsOn : Option[Seq[String]] = None
 ) extends Resource[`AWS::AutoScaling::LaunchConfiguration`] {
@@ -44,9 +45,45 @@ case class `AWS::AutoScaling::LaunchConfiguration`(
 }
 
 object `AWS::AutoScaling::LaunchConfiguration` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::AutoScaling::LaunchConfiguration`] = jsonFormat9(`AWS::AutoScaling::LaunchConfiguration`.apply)
+  implicit val format: JsonFormat[`AWS::AutoScaling::LaunchConfiguration`] = jsonFormat10(`AWS::AutoScaling::LaunchConfiguration`.apply)
+}
+case class BlockDeviceMapping(
+  DeviceName:   Token[String],
+  Ebs:  Option[AutoScalingEBS] = None,
+  NoDevice: Option[Token[Boolean]] = None,
+  VirtualName: Option[Token[String]] = None
+)
+object BlockDeviceMapping extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[BlockDeviceMapping] = jsonFormat4(BlockDeviceMapping.apply)
 }
 
+case class AutoScalingEBS(
+   DeleteOnTermination: Option[Token[Boolean]] = None,
+   Iops: Option[Token[Int]] = None,
+   SnapshotId: Option[Token[String]] = None,
+   VolumeSize: Option[Token[Int]] = None,
+   VolumeType: Option[VolumeType] = None
+ )
+object AutoScalingEBS extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[AutoScalingEBS] = jsonFormat5(AutoScalingEBS.apply)
+}
+
+sealed trait VolumeType
+object VolumeType extends DefaultJsonProtocol{
+  case object Standard extends VolumeType
+  case object IO1 extends VolumeType
+  case object GP2 extends VolumeType
+
+  implicit val format: JsonFormat[VolumeType] = new JsonFormat[VolumeType] {
+    override def write(obj: VolumeType): JsValue = JsString(obj.toString.toLowerCase())
+
+    override def read(json: JsValue): VolumeType = json.toString() match {
+      case "standard" => Standard
+      case "io1" => IO1
+      case "gp2" => GP2
+    }
+  }
+}
 case class `AWS::AutoScaling::ScalingPolicy`(
     name:                 String,
     AdjustmentType:       String,

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
@@ -203,18 +203,20 @@ trait Autoscaling {
     userData:     `Fn::Base64`,
     iam:          Option[Token[ResourceRef[`AWS::IAM::InstanceProfile`]]] = None,
     condition:    Option[ConditionRef] = None,
-    dependsOn:    Option[Seq[String]]  = None
+    dependsOn:    Option[Seq[String]]  = None,
+    blockDevices: Option[Seq[BlockDeviceMapping]] = None
   )(implicit vpc: `AWS::EC2::VPC`) =
     SecurityGroupRoutable from `AWS::AutoScaling::LaunchConfiguration`(
-      name               = name,
-      ImageId            = image,
-      InstanceType       = instanceType,
-      KeyName            = keyName,
-      SecurityGroups     = sgs,
-      UserData           = userData,
-      IamInstanceProfile = iam,
-      Condition          = condition,
-      DependsOn          = dependsOn
+      name                  = name,
+      ImageId               = image,
+      InstanceType          = instanceType,
+      KeyName               = keyName,
+      SecurityGroups        = sgs,
+      UserData              = userData,
+      IamInstanceProfile    = iam,
+      Condition             = condition,
+      DependsOn             = dependsOn,
+      BlockDeviceMappings   = blockDevices
     )
 
   def asg(
@@ -226,7 +228,8 @@ trait Autoscaling {
       userData:     `Fn::Base64`,
       iam:          Option[Token[ResourceRef[`AWS::IAM::InstanceProfile`]]] = None,
       condition:    Option[ConditionRef] = None,
-      dependsOn:    Option[Seq[String]]  = None
+      dependsOn:    Option[Seq[String]]  = None,
+      blockDevices: Option[Seq[BlockDeviceMapping]] = None
     )(
       minSize:     Int,
       maxSize:     Int,
@@ -241,7 +244,7 @@ trait Autoscaling {
       val asgName = baseName + "AutoScale"
 
       val launchConfigSGR @ SecurityGroupRoutable(aLaunchConfig, _, _) =
-        launchConfig(baseName, image, instanceType, keyName, sgs, userData, iam, condition, dependsOn)
+        launchConfig(baseName, image, instanceType, keyName, sgs, userData, iam, condition, dependsOn, blockDevices)
 
       val asg = `AWS::AutoScaling::AutoScalingGroup`(
         name                    = asgName,


### PR DESCRIPTION
I'm using this in the Vault VPC to specify an additional volume for the vault data so I can snapshot it without an outage.  Looks to work fine.