### PR TITLE
Reduce ability to create invalid RDS template

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,11 @@ javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 libraryDependencies ++= Seq (
   // -- testing --
-   "org.scalatest"              %% "scalatest"                % "2.2.1"  % "test"
+   "org.scalatest"  %% "scalatest"     % "2.2.1"  % "test"
   // -- json --
-  ,"io.spray"                   %%  "spray-json"              % "1.3.2"
+  ,"io.spray"       %%  "spray-json"   % "1.3.2"
+  // -- reflection --
+  ,"org.scala-lang" %  "scala-reflect" % scalaVersion.value
 ).map(_.force())
 
 resolvers ++= Seq(

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/EnumFormat.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/EnumFormat.scala
@@ -1,0 +1,15 @@
+package com.monsanto.arch.cloudformation.model
+
+import spray.json._
+import scala.reflect.runtime.universe._
+
+class EnumFormat[T](values: Seq[T], stringifier: T => String = (x: T) => x.toString)
+                   (implicit tag: TypeTag[T]) extends JsonFormat[T] {
+  override def read(json: JsValue): T =
+    json match {
+      case s: JsString =>
+        values.find(x => stringifier(x) == s.value).getOrElse(deserializationError(s.toString + " is not a valid " + tag.tpe))
+      case x => deserializationError(x.toString + " is not a String")
+    }
+  override def write(obj: T) = JsString(stringifier(obj))
+}

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudWatch.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudWatch.scala
@@ -35,18 +35,16 @@ object `AWS::CloudWatch::Alarm` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::CloudWatch::Alarm`] = jsonFormat17(`AWS::CloudWatch::Alarm`.apply)
 }
 
-sealed abstract class `AWS::CloudWatch::Alarm::ComparisonOperator`(val operator: String)
+sealed trait `AWS::CloudWatch::Alarm::ComparisonOperator`
 object `AWS::CloudWatch::Alarm::ComparisonOperator` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::ComparisonOperator`] = new JsonFormat[`AWS::CloudWatch::Alarm::ComparisonOperator`] {
-    def write(obj: `AWS::CloudWatch::Alarm::ComparisonOperator`) = JsString(obj.operator)
-    //TODO
-    def read(json: JsValue) = ???
-  }
+  case object GreaterThanOrEqualToThreshold extends `AWS::CloudWatch::Alarm::ComparisonOperator`
+  case object GreaterThanThreshold          extends `AWS::CloudWatch::Alarm::ComparisonOperator`
+  case object LessThanOrEqualToThreshold    extends `AWS::CloudWatch::Alarm::ComparisonOperator`
+  case object LessThanThreshold             extends `AWS::CloudWatch::Alarm::ComparisonOperator`
+  val values = Seq(GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanOrEqualToThreshold, LessThanThreshold)
+  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::ComparisonOperator`] =
+    new EnumFormat[`AWS::CloudWatch::Alarm::ComparisonOperator`](values)
 }
-case object GreaterThanOrEqualToThreshold extends `AWS::CloudWatch::Alarm::ComparisonOperator`("GreaterThanOrEqualToThreshold")
-case object GreaterThanThreshold          extends `AWS::CloudWatch::Alarm::ComparisonOperator`("GreaterThanThreshold")
-case object LessThanOrEqualToThreshold    extends `AWS::CloudWatch::Alarm::ComparisonOperator`("LessThanOrEqualToThreshold")
-case object LessThanThreshold             extends `AWS::CloudWatch::Alarm::ComparisonOperator`("LessThanThreshold")
 
 case class `AWS::CloudWatch::Alarm::Dimension`(Name: String, Value: Token[ResourceRef[_]])
 object `AWS::CloudWatch::Alarm::Dimension` extends DefaultJsonProtocol {
@@ -54,79 +52,119 @@ object `AWS::CloudWatch::Alarm::Dimension` extends DefaultJsonProtocol {
   def from[A <: Resource[A]](name: String, value: Token[ResourceRef[A]]): `AWS::CloudWatch::Alarm::Dimension` = `AWS::CloudWatch::Alarm::Dimension`(name, value.asInstanceOf[Token[ResourceRef[_]]])
 }
 
-sealed abstract class `AWS::CloudWatch::Alarm::Namespace`(val name: String)
+sealed trait `AWS::CloudWatch::Alarm::Namespace`
 object `AWS::CloudWatch::Alarm::Namespace` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Namespace`] = new JsonFormat[`AWS::CloudWatch::Alarm::Namespace`] {
-    def write(obj: `AWS::CloudWatch::Alarm::Namespace`) = JsString(obj.name)
-    //TODO
-    def read(json: JsValue) = ???
-  }
+  case object `AWS/AutoScaling`      extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/Billing`          extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/CloudFront`       extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/DynamoDB`         extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/ElastiCache`      extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/EBS`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/EC2`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/ELB`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/ElasticMapReduce` extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/Kinesis`          extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/OpsWorks`         extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/Redshift`         extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/RDS`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/Route53`          extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/SNS`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/SQS`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/SWF`              extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/StorageGateway`   extends `AWS::CloudWatch::Alarm::Namespace`
+  val values = Seq(`AWS/AutoScaling`,
+    `AWS/Billing`,
+    `AWS/CloudFront`,
+    `AWS/DynamoDB`,
+    `AWS/ElastiCache`,
+    `AWS/EBS`,
+    `AWS/EC2`,
+    `AWS/ELB`,
+    `AWS/ElasticMapReduce`,
+    `AWS/Kinesis`,
+    `AWS/OpsWorks`,
+    `AWS/Redshift`,
+    `AWS/RDS`,
+    `AWS/Route53`,
+    `AWS/SNS`,
+    `AWS/SQS`,
+    `AWS/SWF`,
+    `AWS/StorageGateway`
+  )
+  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Namespace`] =
+    new EnumFormat[`AWS::CloudWatch::Alarm::Namespace`](values)
 }
-case object `AWS/AutoScaling`      extends `AWS::CloudWatch::Alarm::Namespace`("AWS/AutoScaling")
-case object `AWS/Billing`          extends `AWS::CloudWatch::Alarm::Namespace`("AWS/Billing")
-case object `AWS/CloudFront`       extends `AWS::CloudWatch::Alarm::Namespace`("AWS/CloudFront")
-case object `AWS/DynamoDB`         extends `AWS::CloudWatch::Alarm::Namespace`("AWS/DynamoDB")
-case object `AWS/ElastiCache`      extends `AWS::CloudWatch::Alarm::Namespace`("AWS/ElastiCache")
-case object `AWS/EBS`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/EBS")
-case object `AWS/EC2`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/EC2")
-case object `AWS/ELB`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/ELB")
-case object `AWS/ElasticMapReduce` extends `AWS::CloudWatch::Alarm::Namespace`("AWS/ElasticMapReduce")
-case object `AWS/Kinesis`          extends `AWS::CloudWatch::Alarm::Namespace`("AWS/Kinesis")
-case object `AWS/OpsWorks`         extends `AWS::CloudWatch::Alarm::Namespace`("AWS/OpsWorks")
-case object `AWS/Redshift`         extends `AWS::CloudWatch::Alarm::Namespace`("AWS/Redshift")
-case object `AWS/RDS`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/RDS")
-case object `AWS/Route53`          extends `AWS::CloudWatch::Alarm::Namespace`("AWS/Route53")
-case object `AWS/SNS`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/SNS")
-case object `AWS/SQS`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/SQS")
-case object `AWS/SWF`              extends `AWS::CloudWatch::Alarm::Namespace`("AWS/SWF")
-case object `AWS/StorageGateway`   extends `AWS::CloudWatch::Alarm::Namespace`("AWS/StorageGateway")
 
-sealed abstract class `AWS::CloudWatch::Alarm::Statistic`(val name: String)
+sealed trait `AWS::CloudWatch::Alarm::Statistic`
 object `AWS::CloudWatch::Alarm::Statistic` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Statistic`] = new JsonFormat[`AWS::CloudWatch::Alarm::Statistic`] {
-    def write(obj: `AWS::CloudWatch::Alarm::Statistic`) = JsString(obj.name)
-    //TODO
-    def read(json: JsValue) = ???
-  }
+  case object SampleCount extends `AWS::CloudWatch::Alarm::Statistic`
+  case object Average     extends `AWS::CloudWatch::Alarm::Statistic`
+  case object Sum         extends `AWS::CloudWatch::Alarm::Statistic`
+  case object Minimum     extends `AWS::CloudWatch::Alarm::Statistic`
+  case object Maximum     extends `AWS::CloudWatch::Alarm::Statistic`
+  val values = Seq(SampleCount, Average, Sum, Minimum, Maximum)
+  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Statistic`] =
+    new EnumFormat[`AWS::CloudWatch::Alarm::Statistic`](values)
 }
-case object SampleCount extends `AWS::CloudWatch::Alarm::Statistic`("SampleCount")
-case object Average     extends `AWS::CloudWatch::Alarm::Statistic`("Average")
-case object Sum         extends `AWS::CloudWatch::Alarm::Statistic`("Sum")
-case object Minimum     extends `AWS::CloudWatch::Alarm::Statistic`("Minimum")
-case object Maximum     extends `AWS::CloudWatch::Alarm::Statistic`("Maximum")
 
-sealed abstract class `AWS::CloudWatch::Alarm::Unit`(val name: String)
+sealed trait `AWS::CloudWatch::Alarm::Unit`
 object `AWS::CloudWatch::Alarm::Unit` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Unit`] = new JsonFormat[`AWS::CloudWatch::Alarm::Unit`] {
-    def write(obj: `AWS::CloudWatch::Alarm::Unit`) = JsString(obj.name)
-    //TODO
-    def read(json: JsValue) = ???
-  }
+  case object Seconds            extends `AWS::CloudWatch::Alarm::Unit`
+  case object Microseconds       extends `AWS::CloudWatch::Alarm::Unit`
+  case object Milliseconds       extends `AWS::CloudWatch::Alarm::Unit`
+  case object Bytes              extends `AWS::CloudWatch::Alarm::Unit`
+  case object Kilobytes          extends `AWS::CloudWatch::Alarm::Unit`
+  case object Megabytes          extends `AWS::CloudWatch::Alarm::Unit`
+  case object Gigabytes          extends `AWS::CloudWatch::Alarm::Unit`
+  case object Terabytes          extends `AWS::CloudWatch::Alarm::Unit`
+  case object Bits               extends `AWS::CloudWatch::Alarm::Unit`
+  case object Kilobits           extends `AWS::CloudWatch::Alarm::Unit`
+  case object Megabits           extends `AWS::CloudWatch::Alarm::Unit`
+  case object Gigabits           extends `AWS::CloudWatch::Alarm::Unit`
+  case object Terabits           extends `AWS::CloudWatch::Alarm::Unit`
+  case object Percent            extends `AWS::CloudWatch::Alarm::Unit`
+  case object Count              extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Bytes/Second`     extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Kilobytes/Second` extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Megabytes/Second` extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Gigabytes/Second` extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Terabytes/Second` extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Bits/Second`      extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Kilobits/Second`  extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Megabits/Second`  extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Gigabits/Second`  extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Terabits/Second`  extends `AWS::CloudWatch::Alarm::Unit`
+  case object `Count/Second`     extends `AWS::CloudWatch::Alarm::Unit`
+  case object UnitNone           extends `AWS::CloudWatch::Alarm::Unit`
+  val values = Seq(
+    Seconds,
+    Microseconds,
+    Milliseconds,
+    Bytes,
+    Kilobytes,
+    Megabytes,
+    Gigabytes,
+    Terabytes,
+    Bits,
+    Kilobits,
+    Megabits,
+    Gigabits,
+    Terabits,
+    Percent,
+    Count,
+    `Bytes/Second`,
+    `Kilobytes/Second`,
+    `Megabytes/Second`,
+    `Gigabytes/Second`,
+    `Terabytes/Second`,
+    `Bits/Second`,
+    `Kilobits/Second`,
+    `Megabits/Second`,
+    `Gigabits/Second`,
+    `Terabits/Second`,
+    `Count/Second`,
+    UnitNone
+  )
+  implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Unit`] =
+    new EnumFormat[`AWS::CloudWatch::Alarm::Unit`](values)
 }
-case object Seconds            extends `AWS::CloudWatch::Alarm::Unit`("Seconds")
-case object Microseconds       extends `AWS::CloudWatch::Alarm::Unit`("Microseconds")
-case object Milliseconds       extends `AWS::CloudWatch::Alarm::Unit`("Milliseconds")
-case object Bytes              extends `AWS::CloudWatch::Alarm::Unit`("Bytes")
-case object Kilobytes          extends `AWS::CloudWatch::Alarm::Unit`("Kilobytes")
-case object Megabytes          extends `AWS::CloudWatch::Alarm::Unit`("Megabytes")
-case object Gigabytes          extends `AWS::CloudWatch::Alarm::Unit`("Gigabytes")
-case object Terabytes          extends `AWS::CloudWatch::Alarm::Unit`("Terabytes")
-case object Bits               extends `AWS::CloudWatch::Alarm::Unit`("Bits")
-case object Kilobits           extends `AWS::CloudWatch::Alarm::Unit`("Kilobits")
-case object Megabits           extends `AWS::CloudWatch::Alarm::Unit`("Megabits")
-case object Gigabits           extends `AWS::CloudWatch::Alarm::Unit`("Gigabits")
-case object Terabits           extends `AWS::CloudWatch::Alarm::Unit`("Terabits")
-case object Percent            extends `AWS::CloudWatch::Alarm::Unit`("Percent")
-case object Count              extends `AWS::CloudWatch::Alarm::Unit`("Count")
-case object `Bytes/Second`     extends `AWS::CloudWatch::Alarm::Unit`("Bytes/Second")
-case object `Kilobytes/Second` extends `AWS::CloudWatch::Alarm::Unit`("Kilobytes/Second")
-case object `Megabytes/Second` extends `AWS::CloudWatch::Alarm::Unit`("Megabytes/Second")
-case object `Gigabytes/Second` extends `AWS::CloudWatch::Alarm::Unit`("Gigabytes/Second")
-case object `Terabytes/Second` extends `AWS::CloudWatch::Alarm::Unit`("Terabytes/Second")
-case object `Bits/Second`      extends `AWS::CloudWatch::Alarm::Unit`("Bits/Second")
-case object `Kilobits/Second`  extends `AWS::CloudWatch::Alarm::Unit`("Kilobits/Second")
-case object `Megabits/Second`  extends `AWS::CloudWatch::Alarm::Unit`("Megabits/Second")
-case object `Gigabits/Second`  extends `AWS::CloudWatch::Alarm::Unit`("Gigabits/Second")
-case object `Terabits/Second`  extends `AWS::CloudWatch::Alarm::Unit`("Terabits/Second")
-case object `Count/Second`     extends `AWS::CloudWatch::Alarm::Unit`("Count/Second")
-case object UnitNone           extends `AWS::CloudWatch::Alarm::Unit`("UnitNone")

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticLoadBalancing.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticLoadBalancing.scala
@@ -161,7 +161,8 @@ object `AWS::ElasticLoadBalancing::LoadBalancer` extends DefaultJsonProtocol {
     DependsOn = DependsOn
   )
 
-  implicit val format: JsonFormat[`AWS::ElasticLoadBalancing::LoadBalancer`] = jsonFormat19(`AWS::ElasticLoadBalancing::LoadBalancer`.apply)
+  implicit val format: JsonFormat[`AWS::ElasticLoadBalancing::LoadBalancer`] =
+    jsonFormat19(`AWS::ElasticLoadBalancing::LoadBalancer`.apply)
 }
 
 case class ELBAccessLoggingPolicy(
@@ -178,19 +179,9 @@ sealed trait ELBLoggingEmitInterval
 object ELBLoggingEmitInterval extends DefaultJsonProtocol {
   case object `5`  extends ELBLoggingEmitInterval
   case object `60` extends ELBLoggingEmitInterval
-
-  implicit val format: JsonFormat[ELBLoggingEmitInterval] = new JsonFormat[ELBLoggingEmitInterval] {
-    override def write(obj: ELBLoggingEmitInterval): JsValue = obj match {
-      case `5`  => JsNumber(5)
-      case `60` => JsNumber(60)
-    }
-    override def read(json: JsValue): ELBLoggingEmitInterval = {
-      json.toString() match {
-        case "5"  => `5`
-        case "60" => `60`
-      }
-    }
-  }
+  val values = Seq(`5`, `60`)
+  implicit val format: JsonFormat[ELBLoggingEmitInterval] =
+    new EnumFormat[ELBLoggingEmitInterval](values)
 }
 
 case class ELBAppCookieStickinessPolicy(
@@ -242,18 +233,8 @@ object ELBListenerProtocol extends DefaultJsonProtocol {
   case object HTTPS extends ELBListenerProtocol
   case object SSL   extends ELBListenerProtocol
   case object TCP   extends ELBListenerProtocol
-
-  implicit val format: JsonFormat[ELBListenerProtocol] = new JsonFormat[ELBListenerProtocol] {
-    override def write(obj: ELBListenerProtocol)= JsString(obj.toString)
-    override def read(json: JsValue): ELBListenerProtocol = {
-      json.toString match {
-        case "HTTP"  => HTTP
-        case "HTTPS" => HTTPS
-        case "SSL"   => SSL
-        case "TCP"   => TCP
-      }
-    }
-  }
+  val values = Seq(HTTPS, HTTPS, SSL, TCP)
+  implicit val format: JsonFormat[ELBListenerProtocol] = new EnumFormat[ELBListenerProtocol](values)
 }
 
 case class ELBHealthCheck(
@@ -285,16 +266,8 @@ object NameValuePair extends DefaultJsonProtocol {
 
 sealed trait ELBScheme
 object ELBScheme extends DefaultJsonProtocol {
-  case object internal extends ELBScheme
+  case object internal          extends ELBScheme
   case object `internet-facing` extends ELBScheme
-
-  implicit val format: JsonFormat[ELBScheme] = new JsonFormat[ELBScheme] {
-    override def write(obj: ELBScheme)= JsString(obj.toString)
-    override def read(json: JsValue): ELBScheme = {
-      json.toString match {
-        case "internal"  => internal
-        case "internet-facing" => `internet-facing`
-      }
-    }
-  }
+  val values = Seq(internal, `internet-facing`)
+  implicit val format: JsonFormat[ELBScheme] = new EnumFormat[ELBScheme](values)
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/RDS.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/RDS.scala
@@ -3,78 +3,531 @@ package com.monsanto.arch.cloudformation.model.resource
 import com.monsanto.arch.cloudformation.model._
 import spray.json._
 
-/**
- * Created by Ryan Richt on 2/28/15
- */
-
-// We're mapping "RecordName" to "Name," not to be confused with the name we give the resource in the template, which is called "name" at the Scala level.
-// Similarly, "RecordType" becomes "Type," which is different from the "type" of the resource.
-// Note that if you add, remove, or re-order fields, you must update the JSON mapping.  ORDER COUNTS!
-// Not yet supporting advanced DNS parameters: Failover, GeoLocation, HealthCheckId, Region, SetIdentifier, Weight
-// Also, didn't include HostedZoneId.  Seemed like it'd always be easier to go with HostedZoneName,
-// and it makes the object model cleaner not to support both.
-
-case class `AWS::RDS::DBInstance`(
-  name:                       String,
-  AllocatedStorage:           Token[String],
-  DBInstanceClass:            Token[String],
-  //AllowMajorVersionUpgrade: Option[Boolean] = None,
-  //AllowMinorVersionUpgrade: Option[Boolean] = None,
-  //AvailabilityZone: Option[String] = None, // cannot be set when MultiAZ set
-  BackupRetentionPeriod:      Option[String] = None,
-  DBInstanceIdentifier:       Option[Token[String]] = None,
-  DBName:                     Option[Token[String]] = None,
-  DBParameterGroupName:       Option[ResourceRef[`AWS::RDS::DBParameterGroup`]] = None,
-  //DBSecurityGroups: Option[Seq[ResourceRef[`AWS::RDS::DBSecurityGroup`]]] = None, // cannot be set when VPCSecurityGroups set
-  DBSnapshotIdentifier:       Option[String] = None,
-  DBSubnetGroupName:          Option[ResourceRef[`AWS::RDS::DBSubnetGroup`]] = None, // required for VPC RDS
-  Engine:                     Option[Token[`AWS::RDS::DBInstance::Engine`]] = None, // required if no DBSnapshotIdentifier given
-  EngineVersion:              Option[String] = None,
-  Iops:                       Option[String] = None, // multiple of 1000 between 1000 and 10000
-  //LicenseModel: Option[String] = None,
-  MasterUsername:             Option[Token[String]] = None, // required if no DBSnapshotIdentifier given
-  MasterUserPassword:         Option[Token[String]] = None, // required if no DBSnapshotIdentifier given
-  MultiAZ:                    Option[Boolean] = None, // cannot be set when AvailabilityZone set
-  //OptionGroupName: Option[String] = None,
-  Port:                       Option[String] = None,
-  PreferredBackupWindow:      Option[String] = None,
-  PreferredMaintenanceWindow: Option[String] = None,
-  //PubliclyAccessible: Option[Boolean] = None,
-  //SourceDBInstanceIdentifier: Option[ResourceRef[`AWS::RDS::DBInstance`]] = None, // does not work with MultiAZ, DBSnapshotIdentifier, etc.
-  StorageType:                Option[`AWS::RDS::DBInstance::StorageType`] = None,
-  Tags:                       Option[Seq[AmazonTag]] = None,
-  VPCSecurityGroups:          Option[Seq[ResourceRef[`AWS::EC2::SecurityGroup`]]] = None, // cannot be set when DBSecurityGroups set
-  override val Condition: Option[ConditionRef] = None
-  ) extends Resource[`AWS::RDS::DBInstance`]{
-
+/** There are several mutually exclusive options when creating an RDS instance.
+  * Therefore we make its case class package private and use a builder
+  * pattern to constrain use to those which will create valid instances.
+  *
+  * The builder approach we use does its best to make sure you cannot create a template
+  * with an invalid RDS instance. It may not be perfect, so be sure to double check the
+  * resulting template and let us know of any bugs.
+  *
+  * See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html
+  * and http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
+  *
+  * @param name
+  * @param AllocatedStorage
+  * @param DBInstanceClass
+  * @param AllowMajorVersionUpgrade
+  * @param AutoMinorVersionUpgrade
+  * @param AvailabilityZone cannot be set when MultiAZ set
+  * @param BackupRetentionPeriod cannot be used with SourceDBInstanceIdentifier
+  * @param DBInstanceIdentifier
+  * @param DBName cannot be used with SourceDBInstanceIdentifier
+  * @param DBParameterGroupName
+  * @param DBSecurityGroups cannot be set when VPCSecurityGroups set
+  * @param DBSnapshotIdentifier
+  * @param DBSubnetGroupName required for VPC RDS
+  * @param Engine required if no DBSnapshotIdentifier given
+  * @param EngineVersion
+  * @param Iops various complicated restrictions, see http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html
+  * @param KmsKeyId does not work with DBSnapshotIdentifier or SourceDBInstanceIdentifier, ignored if DBSecurityGroups set
+  * @param LicenseModel
+  * @param MasterUsername required if no DBSnapshotIdentifier given, cannot be used with SourceDBInstanceIdentifier
+  * @param MasterUserPassword required if no DBSnapshotIdentifier given, cannot be used with SourceDBInstanceIdentifier
+  * @param MultiAZ cannot be set when AvailabilityZone set, cannot be used with SourceDBInstanceIdentifier
+  * @param OptionGroupName
+  * @param Port
+  * @param PreferredBackupWindow cannot be used with SourceDBInstanceIdentifier
+  * @param PreferredMaintenanceWindow
+  * @param PubliclyAccessible
+  * @param SourceDBInstanceIdentifier does not work with MultiAZ, DBSnapshotIdentifier, etc.
+  * @param StorageEncrypted ignored if DBSecurityGroups set, does not work with DBSnapshotIdentifier or SourceDBInstanceIdentifier, required with KmsKeyId
+  * @param StorageType ignored if DBSecurityGroups set
+  * @param Tags
+  * @param VPCSecurityGroups cannot be set when DBSecurityGroups set
+  * @param Condition
+  * @param DependsOn
+  * @param DeletionPolicy
+  */
+private[resource] case class `AWS::RDS::DBInstance` (
+  name:                        String,
+  AllocatedStorage:            Either[Int, Token[Int]],
+  DBInstanceClass:             Token[String],
+  AllowMajorVersionUpgrade:    Option[Boolean],
+  AutoMinorVersionUpgrade:     Option[Boolean],
+  AvailabilityZone:            Option[String],
+  BackupRetentionPeriod:       Option[String],
+  //CharacterSetName:          Option[Token[`AWS::RDS::DBInstance::CharacterSetName`]], // Oracle specific http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html
+  //DBClusterIdentifier:       Option[Token[String]], // only for aurora
+  DBInstanceIdentifier:        Option[Token[String]],
+  DBName:                      Option[Token[String]],
+  DBParameterGroupName:        Option[ResourceRef[`AWS::RDS::DBParameterGroup`]],
+  DBSecurityGroups:            Option[Seq[ResourceRef[`AWS::RDS::DBSecurityGroup`]]],
+  DBSnapshotIdentifier:        Option[String],
+  DBSubnetGroupName:           Option[ResourceRef[`AWS::RDS::DBSubnetGroup`]],
+  Engine:                      Option[Token[`AWS::RDS::DBInstance::Engine`]],
+  EngineVersion:               Option[String],
+  Iops:                        Option[Either[Int, Token[Int]]],
+  KmsKeyId:                    Option[Token[String]],
+  LicenseModel:                Option[`AWS::RDS::DBInstance::LicenseModel`],
+  MasterUsername:              Option[Token[String]],
+  MasterUserPassword:          Option[Token[String]],
+  MultiAZ:                     Option[Boolean],
+  OptionGroupName:             Option[String],
+  Port:                        Option[String],
+  PreferredBackupWindow:       Option[String],
+  PreferredMaintenanceWindow:  Option[String],
+  PubliclyAccessible:          Option[Boolean],
+  SourceDBInstanceIdentifier:  Option[Token[ResourceRef[`AWS::RDS::DBInstance`]]],
+  StorageEncrypted:            Option[Boolean],
+  StorageType:                 Option[`AWS::RDS::DBInstance::StorageType`],
+  Tags:                        Option[Seq[AmazonTag]],
+  VPCSecurityGroups:           Option[Seq[ResourceRef[`AWS::EC2::SecurityGroup`]]],
+  override val Condition:      Option[ConditionRef],
+  override val DependsOn:      Option[Seq[String]],
+  override val DeletionPolicy: Option[DeletionPolicy]
+) extends Resource[`AWS::RDS::DBInstance`] {
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 object `AWS::RDS::DBInstance` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::RDS::DBInstance`] = jsonFormat22(`AWS::RDS::DBInstance`.apply)
+  implicit val format: JsonFormat[`AWS::RDS::DBInstance`] = new RootJsonFormat[`AWS::RDS::DBInstance`] {
+    def write(d: `AWS::RDS::DBInstance`) = {
+      val obj = JsObject(
+        "AllocatedStorage"           -> d.AllocatedStorage.toJson,
+        "DBInstanceClass"            -> d.DBInstanceClass.toJson,
+        "AllowMajorVersionUpgrade"   -> d.AllowMajorVersionUpgrade.toJson,
+        "AutoMinorVersionUpgrade"    -> d.AutoMinorVersionUpgrade.toJson,
+        "AvailabilityZone"           -> d.AvailabilityZone.toJson,
+        "BackupRetentionPeriod"      -> d.BackupRetentionPeriod.toJson,
+        "DBInstanceIdentifier"       -> d.DBInstanceIdentifier.toJson,
+        "DBName"                     -> d.DBName.toJson,
+        "DBParameterGroupName"       -> d.DBParameterGroupName.toJson,
+        "DBSecurityGroups"           -> d.DBSecurityGroups.toJson,
+        "DBSnapshotIdentifier"       -> d.DBSnapshotIdentifier.toJson,
+        "DBSubnetGroupName"          -> d.DBSubnetGroupName.toJson,
+        "Engine"                     -> d.Engine.toJson,
+        "EngineVersion"              -> d.EngineVersion.toJson,
+        "Iops"                       -> d.Iops.toJson,
+        "KmsKeyId"                   -> d.KmsKeyId.toJson,
+        "LicenseModel"               -> d.LicenseModel.toJson,
+        "MasterUsername"             -> d.MasterUsername.toJson,
+        "MasterUserPassword"         -> d.MasterUserPassword.toJson,
+        "MultiAZ"                    -> d.MultiAZ.toJson,
+        "OptionGroupName"            -> d.OptionGroupName.toJson,
+        "Port"                       -> d.Port.toJson,
+        "PreferredBackupWindow"      -> d.PreferredBackupWindow.toJson,
+        "PreferredMaintenanceWindow" -> d.PreferredMaintenanceWindow.toJson,
+        "PubliclyAccessible"         -> d.PubliclyAccessible.toJson,
+        "SourceDBInstanceIdentifier" -> d.SourceDBInstanceIdentifier.toJson,
+        "StorageEncrypted"           -> d.StorageEncrypted.toJson,
+        "StorageType"                -> d.StorageType.toJson,
+        "Tags"                       -> d.Tags.toJson,
+        "VPCSecurityGroups"          -> d.VPCSecurityGroups.toJson
+      )
+      obj.copy(fields = obj.fields.filter(_._2 != JsNull))
+    }
+    def read(value: JsValue) = ???
+  }
 }
 
-sealed abstract class `AWS::RDS::DBInstance::Engine`(val name: String)
+/** Enforces that either an RDS Instance is in a VPC or not. */
+sealed trait RdsLocation {
+  private[resource] def location(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance`
+}
+
+/** RDS instance in a VPC.
+  *
+  * @param dbSubnetGroupName AWS::RDS::DBInstance(DBSubnetGroupName)
+  * @param vpcSecurityGroups AWS::RDS::DBInstance(VPCSecurityGroups)
+  */
+case class RdsVpc(
+  dbSubnetGroupName:   ResourceRef[`AWS::RDS::DBSubnetGroup`],
+  vpcSecurityGroups:   Option[Seq[ResourceRef[`AWS::EC2::SecurityGroup`]]] = None
+) extends RdsLocation {
+  private[resource] def location(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(
+      DBSecurityGroups  = None,
+      DBSubnetGroupName = Some(dbSubnetGroupName),
+      VPCSecurityGroups = vpcSecurityGroups
+    )
+}
+
+/** RDS instance not in a VPC, a "classic".
+  *
+  * @param dbSecurityGroups AWS::RDS::DBInstance(DBSecurityGroups)
+  */
+case class RdsClassic(
+  dbSecurityGroups: Option[Seq[ResourceRef[`AWS::RDS::DBSecurityGroup`]]] = None
+) extends RdsLocation {
+  private[resource] def location(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(
+      DBSecurityGroups  = dbSecurityGroups,
+      DBSubnetGroupName = None,
+      VPCSecurityGroups = None
+    )
+}
+
+/** This trait enforces that either a single AZ is given, MultiAZ specified, or the default is used. */
+sealed trait RdsAvailabilityZone {
+  private[resource] def az(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance`
+}
+
+/** Single availability zone RDS instance.
+  *
+  * @param az AWS::RDS::DBInstance(AvailabilityZone), e.g., Some("us-east-1a")
+  */
+case class RdsSingleAZ(az: Option[String] = None) extends RdsAvailabilityZone {
+  private[resource] def az(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(AvailabilityZone = az, MultiAZ = None)
+}
+
+/** Multi-availability zone RDS instance.
+  *
+  * @param multiAz AWS::RDS::DBInstance(MultiAZ)
+  */
+case class RdsMultiAZ(multiAz: Boolean = true) extends RdsAvailabilityZone {
+  private[resource] def az(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(MultiAZ = Some(multiAz), AvailabilityZone = None)
+}
+case class RdsNoAZ() extends RdsAvailabilityZone {
+  private[resource] def az(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` = rdsInstance
+}
+
+/** You can only enable encryption on new RDS instances created in a VPC.
+  * Therefore only NewRDS from RdsSource takes a parameters of this type.
+  * The enforcement of "within a VPC" is done at run time in the RdsBuilder.
+  */
+sealed trait RdsEncryption {
+  /** Must set the AWS::RDS::DBInstance fields related to encryption.
+    *
+    * The fields are StorageEncrypted and KmsKeyId
+    *
+    * @param rdsInstance The RDS instance to modify.
+    * @return A new RDS instances with the appropriate elements set.
+    */
+  private[resource] def encryption(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance`
+}
+
+/** You must have StorageEncrypted set to true is setting KmsKeyId,
+  * so we only take this value in this case class, which sets
+  * StorageEncrypted to true.
+  *
+  * @param kmsKeyId AWS::RDS::DBInstance(KmsKeyId)
+  */
+case class RdsEncryptionStorage(kmsKeyId: Option[Token[String]] = None) extends RdsEncryption {
+  private[resource] def encryption(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(StorageEncrypted = Some(true), KmsKeyId = kmsKeyId)
+}
+
+/** Sets both StorageEncrypted and KmsKeyId to None. */
+case class RdsEncryptionNone() extends RdsEncryption {
+  private[resource] def encryption(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(StorageEncrypted = None, KmsKeyId = None)
+}
+
+/** Enforces the constraint that an RDS instance can only be new,
+  * created from a snapshot, or a read replica of another RDS instance.
+  */
+sealed trait RdsSource {
+  /** Must set the AWS::RDS::DBInstance fields relevant to the origin of an RDS instance.
+    *
+    * The fields are BackupRetentionPeriod, DBName, DBSnapshotIdentifier,
+    * Engine, MasterUsername, MasterUserPassword, PreferredBackupWindow,
+    * SourceDBInstanceIdentifier, and DeletionPolicy.
+    *
+    * @param rdsInstance The RDS instance to modify.
+    * @return A new RDS instances with the appropriate elements set.
+    */
+  private[resource] def source(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance`
+}
+
+/** Provides valid options for a new RDS instance.
+  *
+  * Most parameters map directly to their similarly named parameters for
+  * the AWS::RDS::DBInstance case class.
+  *
+  * @param rdsAvailabilityZone See [[RdsAvailabilityZone]]
+  * @param rdsEncryption See [[RdsEncryptionStorage]]
+  * @param engine AWS::RDS::DBInstance(Engine)
+  * @param masterUsername AWS::RDS::DBInstance(MasterUsername)
+  * @param masterUserPassword AWS::RDS::DBInstance(MasterUserPassword)
+  * @param backupRetentionPeriod AWS::RDS::DBInstance(BackupRetentionPeriod)
+  * @param dbName AWS::RDS::DBInstance(DBName)
+  * @param preferredBackupWindow AWS::RDS::DBInstance(PreferredBackupWindow)
+  * @param deletionPolicy AWS::RDS::DBInstance(DeletionPolicy)
+  */
+case class NewRds(
+  rdsAvailabilityZone:   RdsAvailabilityZone,
+  rdsEncryption:         RdsEncryption,
+  engine:                Token[`AWS::RDS::DBInstance::Engine`],
+  masterUsername:        Token[String],
+  masterUserPassword:    Token[String],
+  backupRetentionPeriod: Option[String]         = None,
+  dbName:                Option[Token[String]]  = None,
+  preferredBackupWindow: Option[String]         = None,
+  deletionPolicy:        Option[DeletionPolicy] = None
+) extends RdsSource {
+  private[resource] def source(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsAvailabilityZone.az(rdsEncryption.encryption(rdsInstance.copy(
+      BackupRetentionPeriod      = backupRetentionPeriod,
+      DBName                     = dbName,
+      DBSnapshotIdentifier       = None,
+      Engine                     = Some(engine),
+      MasterUsername             = Some(masterUsername),
+      MasterUserPassword         = Some(masterUserPassword),
+      PreferredBackupWindow      = preferredBackupWindow,
+      SourceDBInstanceIdentifier = None,
+      DeletionPolicy             = deletionPolicy
+    )))
+}
+
+/** Provides valid options for an RDS instance from a snapshot.
+  *
+  * Most parameters map directly to their similarly named parameters for
+  * the AWS::RDS::DBInstance case class.
+  *
+  * @param rdsAvailabilityZone See [[RdsAvailabilityZone]]
+  * @param dbSnapshotIdentifier AWS::RDS::DBInstance(DBSnapshotIdentifier)
+  * @param backupRetentionPeriod AWS::RDS::DBInstance(BackupRetentionPeriod)
+  * @param dbName AWS::RDS::DBInstance(DBName)
+  * @param engine AWS::RDS::DBInstance(Engine)
+  * @param masterUsername AWS::RDS::DBInstance(MasterUsername)
+  * @param masterUserPassword AWS::RDS::DBInstance(MasterUserPassword)
+  * @param preferredBackupWindow AWS::RDS::DBInstance(PreferredBackupWindow)
+  * @param deletionPolicy AWS::RDS::DBInstance(DeletionPolicy)
+  */
+case class FromSnapshot(
+  rdsAvailabilityZone:   RdsAvailabilityZone,
+  dbSnapshotIdentifier:  String,
+  backupRetentionPeriod: Option[String]                                = None,
+  dbName:                Option[Token[String]]                         = None,
+  engine:                Option[Token[`AWS::RDS::DBInstance::Engine`]] = None,
+  masterUsername:        Option[Token[String]]                         = None,
+  masterUserPassword:    Option[Token[String]]                         = None,
+  preferredBackupWindow: Option[String]                                = None,
+  deletionPolicy:        Option[DeletionPolicy]                        = None
+) extends RdsSource {
+  private[resource] def source(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsAvailabilityZone.az(RdsEncryptionNone().encryption(rdsInstance.copy(
+      BackupRetentionPeriod      = backupRetentionPeriod,
+      DBName                     = dbName,
+      DBSnapshotIdentifier       = Some(dbSnapshotIdentifier),
+      Engine                     = engine,
+      MasterUsername             = masterUsername,
+      MasterUserPassword         = masterUserPassword,
+      PreferredBackupWindow      = preferredBackupWindow,
+      SourceDBInstanceIdentifier = None,
+      DeletionPolicy             = deletionPolicy
+    )))
+}
+
+/** Provide valid options for creating a read replica RDS instance
+  *
+  * @param sourceDBInstanceIdentifier AWS::RDS::DBInstance(SourceDBInstanceIdentifier)
+  * @param availabilityZone AWS::RDS::DBInstance(AvailabilityZone)
+  */
+case class ReadReplica(
+  sourceDBInstanceIdentifier: Token[ResourceRef[`AWS::RDS::DBInstance`]],
+  availabilityZone:           Option[String] = None
+) extends RdsSource {
+  private[resource] def source(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    RdsSingleAZ(availabilityZone).az(RdsEncryptionNone().encryption(rdsInstance.copy(
+      BackupRetentionPeriod      = None,
+      DBName                     = None,
+      Engine                     = None,
+      MasterUsername             = None,
+      MasterUserPassword         = None,
+      PreferredBackupWindow      = None,
+      SourceDBInstanceIdentifier = Some(sourceDBInstanceIdentifier),
+      DeletionPolicy             = None
+    )))
+}
+
+/** Enforce that specified storage has appropriate other values set or not. */
+sealed trait RdsStorageType {
+  /** Must set the AWS::RDS::DBInstance fields relevant to storage.
+    *
+    * Fields relevant to storage are Iops and StorageType.
+    *
+    * @param rdsInstance The RDS instance to modify.
+    * @return A new RDS instances with the appropriate elements set.
+    */
+  private[resource] def storage(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance`
+}
+
+/** No options for standard storage type */
+case class RdsStorageTypeStandard() extends RdsStorageType {
+  private[resource] def storage(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(
+      Iops        = None,
+      StorageType = Some(`AWS::RDS::DBInstance::StorageType`.standard)
+    )
+}
+
+/** No options for gp2 storage type. */
+case class RdsStorageTypeGp2() extends RdsStorageType {
+  private[resource] def storage(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
+    rdsInstance.copy(
+      Iops        = None,
+      StorageType = Some(`AWS::RDS::DBInstance::StorageType`.gp2)
+    )
+}
+
+/** Provide options for an RDS instance with IOPS specified.
+  *
+  * @param iops This value is constrained. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html for details.
+  */
+case class RdsStorageTypeIo1(iops: Either[Int, Token[Int]]) extends RdsStorageType {
+  private def isIopsValueValid(storage: Either[Int, Token[Int]]): Boolean = (iops, storage) match {
+    case (Left(i), Left(s)) =>
+      i >= 1000 &&
+        i <= 30000 &&
+        i % s == 0 &&
+        i / s >= 3 &&
+        i / s <= 10
+    case _ => true
+  }
+
+  private[resource] def storage(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` = {
+    val storage = rdsInstance.AllocatedStorage
+    if (!isIopsValueValid(storage))
+      throw new IllegalArgumentException(s"invalid Iops value $iops for AllocatedStorage $storage. See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html")
+    rdsInstance.copy(
+        Iops        = Some(iops),
+        StorageType = Some(`AWS::RDS::DBInstance::StorageType`.io1)
+    )
+  }
+}
+
+/** No options for the default storage type, as you might expect. */
+case class RdsStorageTypeDefault() extends RdsStorageType {
+  private[resource] def storage(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` = rdsInstance
+}
+
+/** Generic, safe builder for AWS::RDS::DBInstance. */
+object RdsBuilder {
+  /** AWS::RDS::DBInstance builder.
+    *
+    * @param name RDS instance name
+    * @param rdsSource See [[RdsSource]]
+    * @param rdsLocation See [[RdsLocation]]
+    * @param allocatedStorage AWS::RDS::DBInstance(AllocatedStorage)
+    * @param dbInstanceClass AWS::RDS::DBInstance(DBInstanceClass)
+    * @param rdsStorageType See [[RdsStorageType]]
+    * @param allowMajorVersionUpgrade AWS::RDS::DBInstance(AllowMajorVersionUpgrade)
+    * @param autoMinorVersionUpgrade AWS::RDS::DBInstance(AutoMinorVersionUpgrade)
+    * @param dbInstanceIdentifier AWS::RDS::DBInstance(DBInstanceIdentifier)
+    * @param dbParameterGroupName AWS::RDS::DBInstance(DBParameterGroupName)
+    * @param engineVersion AWS::RDS::DBInstance(EngineVersion)
+    * @param licenseModel AWS::RDS::DBInstance(LicenseModel)
+    * @param optionGroupName AWS::RDS::DBInstance(OptionGroupName)
+    * @param port AWS::RDS::DBInstance(Port)
+    * @param preferredMaintenanceWindow AWS::RDS::DBInstance(PreferredMaintenanceWindow)
+    * @param publiclyAccessible AWS::RDS::DBInstance(PubliclyAccessible)
+    * @param tags AWS::RDS::DBInstance(Tags)
+    * @param condition AWS::RDS::DBInstance(Condition)
+    * @param dependsOn AWS::RDS::DBInstance(DependsOn)
+    * @return An instance of [[`AWS::RDS::DBInstance`]].
+    */
+  def buildRds(
+    name:                       String,
+    rdsSource:                  RdsSource,
+    rdsLocation:                RdsLocation,
+    allocatedStorage:           Either[Int,Token[Int]],
+    dbInstanceClass:            Token[String],
+    rdsStorageType:             RdsStorageType                                    = RdsStorageTypeDefault(),
+    allowMajorVersionUpgrade:   Option[Boolean]                                   = None,
+    autoMinorVersionUpgrade:    Option[Boolean]                                   = None,
+    dbInstanceIdentifier:       Option[Token[String]]                             = None,
+    dbParameterGroupName:       Option[ResourceRef[`AWS::RDS::DBParameterGroup`]] = None,
+    engineVersion:              Option[String]                                    = None,
+    licenseModel:               Option[`AWS::RDS::DBInstance::LicenseModel`]      = None,
+    optionGroupName:            Option[String]                                    = None,
+    port:                       Option[String]                                    = None,
+    preferredMaintenanceWindow: Option[String]                                    = None,
+    publiclyAccessible:         Option[Boolean]                                   = None,
+    tags:                       Option[Seq[AmazonTag]]                            = None,
+    condition:                  Option[ConditionRef]                              = None,
+    dependsOn:                  Option[Seq[String]]                               = None
+  ): `AWS::RDS::DBInstance` = {
+    // ensure encryption only requested on VPC RDS instances
+    val isEncrypted: Boolean = rdsSource match {
+      case NewRds(_, RdsEncryptionStorage(_), _, _, _, _, _, _, _) => true
+      case _                                                      => false
+    }
+    val isVpc: Boolean = rdsLocation match {
+      case RdsVpc(_, _) => true
+      case _            => false
+    }
+    if (isEncrypted && !isVpc)
+      throw new IllegalArgumentException("You cannot use storage encryption in non-VPC RDS instances")
+    rdsSource.source(rdsLocation.location(rdsStorageType.storage(`AWS::RDS::DBInstance`(
+      name                       = name,
+      AllocatedStorage           = allocatedStorage,
+      DBInstanceClass            = dbInstanceClass,
+      AllowMajorVersionUpgrade   = allowMajorVersionUpgrade,
+      AutoMinorVersionUpgrade    = autoMinorVersionUpgrade,
+      AvailabilityZone           = None,
+      BackupRetentionPeriod      = None,
+      DBInstanceIdentifier       = dbInstanceIdentifier,
+      DBName                     = None,
+      DBParameterGroupName       = dbParameterGroupName,
+      DBSecurityGroups           = None,
+      DBSnapshotIdentifier       = None,
+      DBSubnetGroupName          = None,
+      Engine                     = None,
+      EngineVersion              = engineVersion,
+      Iops                       = None,
+      KmsKeyId                   = None,
+      LicenseModel               = licenseModel,
+      MasterUsername             = None,
+      MasterUserPassword         = None,
+      MultiAZ                    = None,
+      OptionGroupName            = optionGroupName,
+      Port                       = port,
+      PreferredBackupWindow      = None,
+      PreferredMaintenanceWindow = preferredMaintenanceWindow,
+      PubliclyAccessible         = publiclyAccessible,
+      SourceDBInstanceIdentifier = None,
+      StorageEncrypted           = None,
+      StorageType                = None,
+      Tags                       = tags,
+      VPCSecurityGroups          = None,
+      Condition                  = condition,
+      DependsOn                  = dependsOn,
+      DeletionPolicy             = None
+    ))))
+  }
+}
+
+sealed trait `AWS::RDS::DBInstance::Engine`
 object `AWS::RDS::DBInstance::Engine` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::RDS::DBInstance::Engine`] = new JsonFormat[`AWS::RDS::DBInstance::Engine`] {
-    def write(obj: `AWS::RDS::DBInstance::Engine`) = JsString(obj.name)
-    //TODO
-    def read(json: JsValue) = ???
-  }
+  case object MySQL    extends `AWS::RDS::DBInstance::Engine`
+  case object postgres extends `AWS::RDS::DBInstance::Engine`
+  val values = Seq(MySQL, postgres)
+  implicit val format: JsonFormat[`AWS::RDS::DBInstance::Engine`] =
+    new EnumFormat[`AWS::RDS::DBInstance::Engine`](values)
 }
-case object `AWS::RDS::DBInstance::Engine::MySQL`    extends `AWS::RDS::DBInstance::Engine`("MySQL")
-case object `AWS::RDS::DBInstance::Engine::postgres` extends `AWS::RDS::DBInstance::Engine`("postgres")
 
-sealed abstract class `AWS::RDS::DBInstance::StorageType`(val name: String)
+sealed trait `AWS::RDS::DBInstance::StorageType`
 object `AWS::RDS::DBInstance::StorageType` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::RDS::DBInstance::StorageType`] = new JsonFormat[`AWS::RDS::DBInstance::StorageType`] {
-    def write(obj: `AWS::RDS::DBInstance::StorageType`) = JsString(obj.name)
-    //TODO
-    def read(json: JsValue) = ???
-  }
+  case object standard extends `AWS::RDS::DBInstance::StorageType`
+  case object gp2      extends `AWS::RDS::DBInstance::StorageType`
+  case object io1      extends `AWS::RDS::DBInstance::StorageType`
+  val values = Seq(standard, gp2, io1)
+  implicit val format: JsonFormat[`AWS::RDS::DBInstance::StorageType`] =
+    new EnumFormat[`AWS::RDS::DBInstance::StorageType`](values)
 }
-case object `AWS::RDS::DBInstance::Storage::standard` extends `AWS::RDS::DBInstance::StorageType`("standard")
-case object `AWS::RDS::DBInstance::Storage::gp2`      extends `AWS::RDS::DBInstance::StorageType`("gp2")
-case object `AWS::RDS::DBInstance::Storage::io1`      extends `AWS::RDS::DBInstance::StorageType`("io1")
+
+sealed trait `AWS::RDS::DBInstance::LicenseModel`
+object `AWS::RDS::DBInstance::LicenseModel` extends DefaultJsonProtocol {
+  case object `license-included`       extends `AWS::RDS::DBInstance::LicenseModel`
+  case object `bring-your-own-license` extends `AWS::RDS::DBInstance::LicenseModel`
+  case object `general-public-license` extends `AWS::RDS::DBInstance::LicenseModel`
+  val values = Seq(`license-included`, `bring-your-own-license`, `general-public-license`)
+  implicit val format: JsonFormat[`AWS::RDS::DBInstance::LicenseModel`] =
+    new EnumFormat[`AWS::RDS::DBInstance::LicenseModel`](values)
+}
 
 case class `AWS::RDS::DBParameterGroup`(
   name:        String,
@@ -83,7 +536,7 @@ case class `AWS::RDS::DBParameterGroup`(
   Parameters:  Option[Map[String,String]] = None,
   Tags:        Option[Seq[AmazonTag]] = None,
   override val Condition: Option[ConditionRef] = None
-  ) extends Resource[`AWS::RDS::DBParameterGroup`]{
+) extends Resource[`AWS::RDS::DBParameterGroup`]{
 
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
@@ -91,14 +544,23 @@ object `AWS::RDS::DBParameterGroup` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::RDS::DBParameterGroup`] = jsonFormat6(`AWS::RDS::DBParameterGroup`.apply)
 }
 
+/** Database security group.
+  *
+  * @param name
+  * @param DBSecurityGroupIngress Finite list of keys: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-security-group-rule.html
+  * @param GroupDescription
+  * @param EC2VpcId
+  * @param Tags
+  * @param Condition
+  */
 case class `AWS::RDS::DBSecurityGroup`(
   name:                   String,
-  DBSecurityGroupIngress: Seq[Map[String,String]], //finite list of keys: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-security-group-rule.html
+  DBSecurityGroupIngress: Seq[RDSDBSecurityGroupRule],
   GroupDescription:       String,
   EC2VpcId:               Option[ResourceRef[`AWS::EC2::VPC`]] = None,
-  Tags:                   Option[Seq[AmazonTag]] = None,
-  override val Condition: Option[ConditionRef] = None
-  ) extends Resource[`AWS::RDS::DBSecurityGroup`]{
+  Tags:                   Option[Seq[AmazonTag]]               = None,
+  override val Condition: Option[ConditionRef]                 = None
+) extends Resource[`AWS::RDS::DBSecurityGroup`]{
 
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
@@ -106,13 +568,23 @@ object `AWS::RDS::DBSecurityGroup` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::RDS::DBSecurityGroup`] = jsonFormat6(`AWS::RDS::DBSecurityGroup`.apply)
 }
 
+case class RDSDBSecurityGroupRule(
+  CIDRIP:                  Option[Token[CidrBlock]],
+  EC2SecurityGroupId:      Option[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
+  EC2SecurityGroupName:    Option[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
+  EC2SecurityGroupOwnerId: Option[String]
+)
+object RDSDBSecurityGroupRule extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[RDSDBSecurityGroupRule] = jsonFormat4(RDSDBSecurityGroupRule.apply)
+}
+
 case class `AWS::RDS::DBSubnetGroup`(
   name:                     String,
   DBSubnetGroupDescription: String,
   SubnetIds:                Seq[ResourceRef[`AWS::EC2::Subnet`]],
   Tags:                     Option[Seq[AmazonTag]] = None,
-  override val Condition: Option[ConditionRef] = None
-  ) extends Resource[`AWS::RDS::DBSubnetGroup`]{
+  override val Condition: Option[ConditionRef]     = None
+) extends Resource[`AWS::RDS::DBSubnetGroup`]{
 
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
@@ -13,11 +13,12 @@ import scala.reflect.NameTransformer
 
 // serializes to Type and Properties
 abstract class Resource[R <: Resource[R] : ClassTag : JsonFormat]{ self: Resource[R] =>
-  val Type = NameTransformer.decode( implicitly[ClassTag[R]].runtimeClass.getSimpleName )
+  val Type = NameTransformer.decode(implicitly[ClassTag[R]].runtimeClass.getSimpleName)
   val name: String
 
-  val Condition: Option[ConditionRef] = None
-  val DependsOn: Option[Seq[String]] = None
+  val Condition:      Option[ConditionRef]   = None
+  val DependsOn:      Option[Seq[String]]    = None
+  val DeletionPolicy: Option[DeletionPolicy] = None
 
   private val _format: JsonFormat[R] = implicitly[JsonFormat[R]] // the magic
   type RR = Resource[R] // and his assistant
@@ -36,10 +37,11 @@ object Resource extends DefaultJsonProtocol {
         val outputFields = Map(
           "Type" -> JsString(obj.Type),
           "Metadata" -> raw.fields.getOrElse("Metadata", JsNull),
-          "Properties" -> JsObject(raw.fields - "name" - "Metadata" - "UpdatePolicy" - "Condition" - "DependsOn"),
+          "Properties" -> JsObject(raw.fields - "name" - "Metadata" - "UpdatePolicy" - "Condition" - "DependsOn" - "DeletionPolicy"),
           "UpdatePolicy" -> raw.fields.getOrElse("UpdatePolicy", JsNull),
           "Condition" -> obj.Condition.map(_.toJson).getOrElse(JsNull),
-          "DependsOn" -> obj.DependsOn.map(dependencies => JsArray(dependencies.map(_.toJson).toVector)).getOrElse(JsNull)
+          "DependsOn" -> obj.DependsOn.map(dependencies => JsArray(dependencies.map(_.toJson).toVector)).getOrElse(JsNull),
+          "DeletionPolicy" -> obj.DeletionPolicy.map(_.toJson).getOrElse(JsNull)
         ).filter(_._2 != JsNull)
 
         JsObject(outputFields)
@@ -48,4 +50,14 @@ object Resource extends DefaultJsonProtocol {
 
     def write(objs: Seq[Resource[_]]) = JsObject( objs.map( o => o.name -> format.write(o) ).toMap )
   }
+}
+
+// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+sealed trait DeletionPolicy
+object DeletionPolicy extends DefaultJsonProtocol {
+  case object Delete   extends DeletionPolicy
+  case object Retain   extends DeletionPolicy
+  case object Snapshot extends DeletionPolicy // only available for AWS::EC2::Volume, AWS::RDS::DBInstance, and AWS::Redshift::Cluster
+  val values = Seq(Delete, Retain, Snapshot)
+  implicit val format: JsonFormat[DeletionPolicy] = new EnumFormat[DeletionPolicy](values)
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
@@ -107,13 +107,13 @@ trait Instance {
         AlarmActions = Some(Seq(`Fn::Join`(":", Seq("arn:aws:automate", `AWS::Region`, "ec2:recover")))),
         AlarmDescription = Some(s"Auto recover $description"),
         AlarmName = Some(`Fn::Join`("-", Seq(s"$description-alarm", `AWS::StackName`))),
-        ComparisonOperator = GreaterThanThreshold,
+        ComparisonOperator = `AWS::CloudWatch::Alarm::ComparisonOperator`.GreaterThanThreshold,
         Dimensions = Some(Seq(`AWS::CloudWatch::Alarm::Dimension`.from("InstanceId", ec2))),
         EvaluationPeriods = "2",
         MetricName = "StatusCheckFailed_System",
-        Namespace = `AWS/EC2`,
+        Namespace = `AWS::CloudWatch::Alarm::Namespace`.`AWS/EC2`,
         Period = "60",
-        Statistic = Minimum,
+        Statistic = `AWS::CloudWatch::Alarm::Statistic`.Minimum,
         Threshold = "0"
       )
   }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
@@ -1,0 +1,252 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model._
+import org.scalatest.{Matchers, FunSpec}
+import spray.json._
+
+class RDS_UT extends FunSpec with Matchers {
+  describe("AWS::RDS::DBInstance") {
+    val vpc = `AWS::EC2::VPC`(
+      name      = "VPC",
+      CidrBlock = CidrBlock(10, 10, 10, 10, 16),
+      Tags      = Seq()
+    )
+    val dbSubnet = `AWS::EC2::Subnet`(
+      name             = "Subnet",
+      VpcId            = ResourceRef(vpc),
+      AvailabilityZone = "us-east-1a",
+      CidrBlock        = CidrBlock(10, 10, 10, 10, 24),
+      Tags             = Seq()
+    )
+    val subnetGroupName = "DBSubnetGroup"
+    val dbSubnetGroup = `AWS::RDS::DBSubnetGroup`(
+      name                     = subnetGroupName,
+      DBSubnetGroupDescription = "Not a real group",
+      SubnetIds                = Seq(ResourceRef(dbSubnet))
+    )
+    val rdsInVpc = RdsVpc(dbSubnetGroupName = ResourceRef(dbSubnetGroup))
+    val username = "route"
+    val pw = "secret"
+    val newEncryptedRds = NewRds(
+      rdsAvailabilityZone = RdsMultiAZ(),
+      rdsEncryption       = RdsEncryptionStorage(),
+      engine              = `AWS::RDS::DBInstance::Engine`.postgres,
+      masterUsername      = username,
+      masterUserPassword  = pw
+    )
+    val instanceClass = "db.t2.large"
+    val storage = 5
+    val rdsInstance = RdsBuilder.buildRds(
+      name             = "TestRds",
+      rdsSource        = newEncryptedRds,
+      rdsLocation      = rdsInVpc,
+      allocatedStorage = Left(storage),
+      dbInstanceClass  = instanceClass,
+      rdsStorageType   = RdsStorageTypeStandard()
+    )
+
+    it("should create a valid new RDS database instance") {
+      val expected = JsObject(
+        "TestRds" -> JsObject(
+          "Type" -> JsString("AWS::RDS::DBInstance"),
+          "Properties" -> JsObject(
+            "AllocatedStorage" -> JsNumber(storage),
+            "DBInstanceClass" -> JsString(instanceClass),
+            "Engine" -> JsString("postgres"),
+            "MasterUsername" -> JsString(username),
+            "MasterUserPassword" -> JsString(pw),
+            "MultiAZ" -> JsBoolean(true),
+            "StorageEncrypted" -> JsBoolean(true),
+            "StorageType" -> JsString("standard"),
+            "DBSubnetGroupName" -> JsObject("Ref" -> JsString(subnetGroupName))
+          )
+        )
+      )
+      Seq[Resource[_]](rdsInstance).toJson should be (expected)
+    }
+
+    it("should create a valid pIOPS RDS database instance from snapshot") {
+      val secGroupName = "SecurityGroup"
+      val secGroup = `AWS::RDS::DBSecurityGroup`(
+        name                   = secGroupName,
+        DBSecurityGroupIngress = Seq(),
+        GroupDescription       = "Not a real group"
+      )
+      val dbSnapshotId = "NotARealSnapshot"
+      val az = "us-east-1d"
+      val rdsFromSnapshot = FromSnapshot(
+        rdsAvailabilityZone  = RdsSingleAZ(az = Some(az)),
+        dbSnapshotIdentifier = dbSnapshotId
+      )
+      val iops = 2000
+      val iopsStorage = 500
+      val rdsInstance = RdsBuilder.buildRds(
+        name             = "TestRdsFromSnapshot",
+        rdsSource        = rdsFromSnapshot,
+        rdsLocation      = RdsClassic(dbSecurityGroups = Some(Seq(ResourceRef(secGroup)))),
+        allocatedStorage = Left(iopsStorage),
+        dbInstanceClass  = instanceClass,
+        rdsStorageType   = RdsStorageTypeIo1(iops = Left(iops))
+      )
+      val expected = JsObject(
+        "TestRdsFromSnapshot" -> JsObject(
+          "Type" -> JsString("AWS::RDS::DBInstance"),
+          "Properties" -> JsObject(
+            "AllocatedStorage" -> JsNumber(iopsStorage),
+            "AvailabilityZone" -> JsString(az),
+            "DBInstanceClass" -> JsString(instanceClass),
+            "DBSecurityGroups" -> JsArray(JsObject("Ref" -> JsString(secGroupName))),
+            "DBSnapshotIdentifier" -> JsString(dbSnapshotId),
+            "Iops" -> JsNumber(iops),
+            "StorageType" -> JsString("io1")
+          )
+        )
+      )
+      Seq[Resource[_]](rdsInstance).toJson should be (expected)
+    }
+
+    it("should create a read replica") {
+      val replica = RdsBuilder.buildRds(
+        name             = "Replicant",
+        rdsSource        = ReadReplica(sourceDBInstanceIdentifier = ResourceRef(rdsInstance)),
+        rdsLocation      = rdsInVpc,
+        allocatedStorage = Left(storage),
+        dbInstanceClass  = instanceClass,
+        rdsStorageType   = RdsStorageTypeStandard()
+      )
+      val expected = JsObject(
+        "Replicant" -> JsObject(
+          "Type" -> JsString("AWS::RDS::DBInstance"),
+          "Properties" -> JsObject(
+            "AllocatedStorage" -> JsNumber(storage),
+            "DBInstanceClass" -> JsString(instanceClass),
+            "StorageType" -> JsString("standard"),
+            "DBSubnetGroupName" -> JsObject("Ref" -> JsString(subnetGroupName)),
+            "SourceDBInstanceIdentifier" -> JsObject("Ref" -> JsString(rdsInstance.name))
+          )
+        )
+      )
+      Seq[Resource[_]](replica).toJson should be (expected)
+    }
+
+    it("should not create an encrypted RDS instance outside a VPC") {
+      val message = "You cannot use storage encryption in non-VPC RDS instances"
+      try {
+        RdsBuilder.buildRds(
+          name             = "TestRds",
+          rdsSource        = newEncryptedRds,
+          rdsLocation      = RdsClassic(),
+          allocatedStorage = Left(10),
+          dbInstanceClass  = instanceClass
+        )
+      } catch {
+        case e: IllegalArgumentException if e.getMessage == message =>
+      }
+    }
+
+    it("should not create an RDS with incompatible iops and storage parameters") {
+      try {
+        RdsBuilder.buildRds(
+          name = "TheSource",
+          rdsSource = newEncryptedRds,
+          rdsLocation = rdsInVpc,
+          allocatedStorage = Left(5),
+          dbInstanceClass = instanceClass,
+          rdsStorageType = RdsStorageTypeIo1(iops = Left(2000))
+        )
+      } catch {
+        case e: IllegalArgumentException if e.getMessage.startsWith("invalid Iops value") =>
+      }
+    }
+
+    it("should create an RDS instance using parameters") {
+      val rdsUser = StringParameter(
+        name        = "RDSUser",
+        Description = Some("Sets the user for the infrastructure RDS instance")
+      )
+      val rdsPassword = StringParameter(
+        name                  = "RDSPassword",
+        Description           = Some("Sets the password for the infrastructure RDS instance"),
+        MinLength             = Some(StringBackedInt(8)),
+        MaxLength             = Some(StringBackedInt(128)),
+        AllowedPattern        = Some("^[^\"@/]+$"),
+        ConstraintDescription = Some("Must be between 8 and 128 characters. \", @, and / are not allowed"),
+        NoEcho                = Some(true)
+      )
+      val rdsAllocatedStorage = NumberParameter(
+        name                  = "RDSAllocatedStorage",
+        Description           = Some("The size in GB of the storage for the infrastructure RDS instance"),
+        MinValue              = Some(StringBackedInt(5)),
+        ConstraintDescription = Some("Must be an integer greater than or equal to 5"),
+        Default               = Some(StringBackedInt(5))
+      )
+      val rdsInstanceClass = StringParameter(
+        name                  = "RDSInstanceClass",
+        Description           = Some("The instance class for the infrastructure RDS Instance"),
+        AllowedValues         = Some(Seq("db.t2.micro", "db.t2.small")),
+        ConstraintDescription = Some("Must be an RDS instance that supports encryption"),
+        Default               = Some("db.t2.micro")
+      )
+      val dbName = "RdsUP"
+      val rdsInstance = RdsBuilder.buildRds(
+        name                       = "RdsUsingParameters",
+        rdsSource                  = NewRds(
+          rdsAvailabilityZone   = RdsNoAZ(),
+          rdsEncryption         = RdsEncryptionNone(),
+          engine                = `AWS::RDS::DBInstance::Engine`.postgres,
+          masterUsername        = ParameterRef(rdsUser),
+          masterUserPassword    = ParameterRef(rdsPassword),
+          backupRetentionPeriod = Some("7"),
+          dbName                = Some(dbName)
+        ),
+        rdsLocation                = RdsClassic(),
+        allocatedStorage           = Right(ParameterRef(rdsAllocatedStorage)),
+        dbInstanceClass            = ParameterRef(rdsInstanceClass),
+        rdsStorageType             = RdsStorageTypeGp2(),
+        allowMajorVersionUpgrade   = Some(false),
+        autoMinorVersionUpgrade    = Some(true),
+        dbInstanceIdentifier       = Some(`Fn::Join`("-", Seq(`AWS::StackName`, dbName))),
+        publiclyAccessible         = Some(false),
+        tags                       = Some(AmazonTag.fromName(dbName))
+      )
+      val expected = JsObject(
+        "RdsUsingParameters" -> JsObject(
+          "Type" -> JsString("AWS::RDS::DBInstance"),
+          "Properties" -> JsObject(
+            "AllocatedStorage" -> JsObject("Ref" -> JsString(rdsAllocatedStorage.name)),
+            "AllowMajorVersionUpgrade" -> JsBoolean(false),
+            "AutoMinorVersionUpgrade" -> JsBoolean(true),
+            "BackupRetentionPeriod" -> JsString("7"),
+            "DBInstanceClass" -> JsObject("Ref" -> JsString(rdsInstanceClass.name)),
+            "DBInstanceIdentifier" -> JsObject(
+              "Fn::Join" -> JsArray(
+                JsString("-"),
+                JsArray(
+                  JsObject("Ref" -> JsString("AWS::StackName")),
+                  JsString(dbName)
+                )
+              )
+            ),
+            "DBName" -> JsString(dbName),
+            "Engine" -> JsString("postgres"),
+            "MasterUsername" -> JsObject("Ref" -> JsString(rdsUser.name)),
+            "MasterUserPassword" -> JsObject("Ref" -> JsString(rdsPassword.name)),
+            "PubliclyAccessible" -> JsBoolean(false),
+            "StorageType" -> JsString("gp2"),
+            "Tags" -> JsArray(JsObject(
+              "Key" -> JsString("Name"),
+              "Value" -> JsObject("Fn::Join" -> JsArray(
+                JsString("-"),
+                JsArray(
+                  JsString(dbName),
+                  JsObject("Ref" -> JsString("AWS::StackName"))
+                )
+              ))
+            ))
+          )
+        )
+      )
+      Seq[Resource[_]](rdsInstance).toJson should be (expected)
+    }
+  }
+}


### PR DESCRIPTION
Implement a complex mechanism for reducing the chance of creating JSON
for an RDS DBInstance that is invalid.  My hope is that the complexity
equals and is not greater than the complexity inherent in the
restrictions around RDS creation.  There is still one run-time check
around storage encryption since specifying it is only valid on new
instances created within VPCs.

A couple other minor changes:
-   Clean up build.sbt
-   Implement and use EnumFormat for all enumerations JSON serialization

When this change gets merged, the release will have to increment the major version number since this breaks RDS backward compatibility badly.