### PR TITLE
Aws token string interpolation

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model.scala
@@ -133,29 +133,11 @@ import scala.language.implicitConversions
 
 package object model {
 
-  case class Zipper[A](parts: Seq[A]*) extends Traversable[A] {
-    override def foreach[U](f: (A) => U): Unit = {
-      val i = parts.map(_.iterator)
-      while (i.exists(_.hasNext))
-        i.foreach { v =>
-          if (v.hasNext) {
-            f(v.next)
-          }
-        }
-    }
-  }
-
   implicit def parameter2TokenString(parameter : StringParameter) : Token[String] = ParameterRef(parameter)
+
   implicit class AwsToken(val sc: StringContext) extends AnyVal {
 
-    def aws(args: Token[String]*): Token[String] = {
-      if (args.isEmpty) {
-        sc.parts.mkString("")
-      } else {
-        val tokens = Zipper(sc.parts.filterNot(_.isEmpty).map(StringToken), args.toSeq).toArray.toSeq
-        `Fn::Join`("", tokens)
-      }
-    }
-  }
+    def aws(tokens: Token[String]*) = AwsStringInterpolation(sc, tokens)
 
+  }
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model.scala
@@ -148,6 +148,7 @@ package object model {
   implicit class AwsToken(val sc: StringContext) extends AnyVal {
     def any2Token(a: Any): Token[String] = a match {
       case token: Token[String] => token
+      case parameter: StringParameter => ParameterRef(parameter)
       case s: String => s
       case amznFunc: AmazonFunctionCall[String] => amznFunc
     }
@@ -157,7 +158,6 @@ package object model {
         sc.parts.mkString("")
       } else {
         val tokens = Zipper(sc.parts.filterNot(_.isEmpty).map(StringToken), args.toSeq.map(any2Token)).toArray.toSeq
-        println("tokens: " + tokens)
         `Fn::Join`("", tokens)
       }
     }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model.scala
@@ -145,19 +145,14 @@ package object model {
     }
   }
 
+  implicit def parameter2TokenString(parameter : StringParameter) : Token[String] = ParameterRef(parameter)
   implicit class AwsToken(val sc: StringContext) extends AnyVal {
-    def any2Token(a: Any): Token[String] = a match {
-      case token: Token[String] => token
-      case parameter: StringParameter => ParameterRef(parameter)
-      case s: String => s
-      case amznFunc: AmazonFunctionCall[String] => amznFunc
-    }
 
-    def aws(args: Any*): Token[String] = {
+    def aws(args: Token[String]*): Token[String] = {
       if (args.isEmpty) {
         sc.parts.mkString("")
       } else {
-        val tokens = Zipper(sc.parts.filterNot(_.isEmpty).map(StringToken), args.toSeq.map(any2Token)).toArray.toSeq
+        val tokens = Zipper(sc.parts.filterNot(_.isEmpty).map(StringToken), args.toSeq).toArray.toSeq
         `Fn::Join`("", tokens)
       }
     }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AwsStringInterpolation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AwsStringInterpolation.scala
@@ -1,0 +1,31 @@
+package com.monsanto.arch.cloudformation.model
+
+/**
+  * Created by Tyler Southwick on 11/20/15.
+  */
+object AwsStringInterpolation {
+
+  /**
+    * Takes a sequence of objects and zips them together such that
+    */
+  case class Zipper[A](parts: Seq[A]*) extends Traversable[A] {
+    override def foreach[U](f: (A) => U): Unit = {
+      val i = parts.map(_.iterator)
+      while (i.exists(_.hasNext))
+        i.foreach { v =>
+          if (v.hasNext) {
+            f(v.next)
+          }
+        }
+    }
+  }
+
+  def apply(sc : StringContext, tokens : Seq[Token[String]]) : Token[String] = {
+      if (tokens.isEmpty) {
+        sc.parts.mkString("")
+      } else {
+        val zippedTokens = Zipper(sc.parts.filterNot(_.isEmpty).map(StringToken), tokens).toArray.toSeq
+        `Fn::Join`("", zippedTokens)
+      }
+    }
+}

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
@@ -1,5 +1,6 @@
 package com.monsanto.arch.cloudformation.model
 
+import com.monsanto.arch.cloudformation.model.AwsStringInterpolation.Zipper
 import org.scalatest.{Matchers, FunSpec}
 
 class AwsTokenSpec extends FunSpec with Matchers {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
@@ -10,13 +10,23 @@ class AwsTokenSpec extends FunSpec with Matchers {
     fun shouldEqual StringToken("test")
   }
 
-  it("should join parameter ref tokens") {
+  it("should join ParameterRef tokens") {
     val param = ParameterRef(StringParameter("that"))
     val fun = aws"test$param"
 
     fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
       StringToken("test"),
       param
+    )))
+  }
+
+  it("should join Parameter") {
+    val param = StringParameter("that")
+    val fun = aws"test$param"
+
+    fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
+      StringToken("test"),
+      ParameterRef(param)
     )))
   }
 

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
@@ -1,0 +1,52 @@
+package com.monsanto.arch.cloudformation.model
+
+import org.scalatest.{Matchers, FunSpec}
+
+class AwsTokenSpec extends FunSpec with Matchers {
+
+  it("should generate simple string if no expressions") {
+    val fun = aws"test"
+
+    fun shouldEqual StringToken("test")
+  }
+
+  it("should join parameter ref tokens") {
+    val param = ParameterRef(StringParameter("that"))
+    val fun = aws"test$param"
+
+    fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
+      StringToken("test"),
+      param
+    )))
+  }
+
+  it("should join Fn::GetAtt ref tokens") {
+    val getAtt = `Fn::GetAtt`(Seq("that"))
+    val fun = aws"test${getAtt}something"
+
+    fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
+      StringToken("test"),
+      getAtt,
+      StringToken("something")
+    )))
+  }
+  it("should join tokens") {
+    val getAtt : Token[String] = `Fn::GetAtt`(Seq("that"))
+    val fun = aws"test${getAtt}something"
+
+    fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
+      StringToken("test"),
+      getAtt,
+      StringToken("something")
+    )))
+  }
+
+  describe("zipper") {
+    it("should combine unevent lists") {
+      val zipper = Zipper(Seq("a", "b", "c"), Seq("d", "e"), Seq("f"))
+      zipper.toSeq shouldEqual Seq(
+        "a", "d", "f", "b", "e", "c"
+      )
+    }
+  }
+}


### PR DESCRIPTION
added a string interpolator that generates Fn:Join statements by using scala string interpolation.

For example:

```
val token : Token[String] = ParameterRef(bucketNameParameter)
val string = aws"s3://$token/my/s3/path"
```

BTW, the guidelines for contributing has a broken link