### PR TITLE
Aws token string interpolation

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AwsStringInterpolation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AwsStringInterpolation.scala
@@ -24,7 +24,10 @@ object AwsStringInterpolation {
       if (tokens.isEmpty) {
         sc.parts.mkString("")
       } else {
-        val zippedTokens = Zipper(sc.parts.filterNot(_.isEmpty).map(StringToken), tokens).toArray.toSeq
+        val zippedTokens = Zipper(sc.parts.map(StringToken), tokens).toArray.toSeq.filterNot {
+          case StringToken(s) if s.isEmpty => true
+          case _ => false
+        }
         `Fn::Join`("", zippedTokens)
       }
     }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
@@ -31,6 +31,21 @@ class AwsTokenSpec extends FunSpec with Matchers {
     )))
   }
 
+  it("should join multiple Parameters") {
+    val param1 = StringParameter("that")
+    val param2 = StringParameter("this")
+    val param3 = StringParameter("these")
+    val fun = aws"test$param1${param2}hello$param3"
+
+    fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
+      StringToken("test"),
+      ParameterRef(param1),
+      ParameterRef(param2),
+      StringToken("hello"),
+      ParameterRef(param3)
+    )))
+  }
+
   it("should join Fn::GetAtt ref tokens") {
     val getAtt = `Fn::GetAtt`(Seq("that"))
     val fun = aws"test${getAtt}something"

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
@@ -11,6 +11,14 @@ class AwsTokenSpec extends FunSpec with Matchers {
     fun shouldEqual StringToken("test")
   }
 
+  it("should generate simple string if no only string substitutions") {
+    val lost : Token[String] = "lost"
+    val world : Token[String] = "world"
+    val fun = aws"hello$lost$world"
+
+    fun shouldEqual StringToken("hellolostworld")
+  }
+
   it("should join ParameterRef tokens") {
     val param = ParameterRef(StringParameter("that"))
     val fun = aws"test$param"

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/AwsTokenSpec.scala
@@ -67,6 +67,19 @@ class AwsTokenSpec extends FunSpec with Matchers {
     )))
   }
 
+  it("should optimize join tokens") {
+    val getAtt : Token[String] = `Fn::GetAtt`(Seq("that"))
+    val test1 = "test1"
+    val test2 = "test2"
+    val fun = aws"test$getAtt${test1}something$test2"
+
+    fun shouldEqual FunctionCallToken(`Fn::Join`("", Seq(
+      StringToken("test"),
+      getAtt,
+      StringToken(s"${test1}something$test2")
+    )))
+  }
+
   describe("zipper") {
     it("should combine unevent lists") {
       val zipper = Zipper(Seq("a", "b", "c"), Seq("d", "e"), Seq("f"))


### PR DESCRIPTION
Found some bugs in the previous pull request, specifically around interpolating strings of the form:

aws"hello$token1${token2}world"

It was getting the order wrong due to my mis-reading of the interpolation API.

This will also optimize out multiple StringToken(s) in a row, ie converting Fn::Join('', ['hello', 'world']) into just "helloworld"