### PR TITLE
preserving object order

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Condition.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Condition.scala
@@ -2,6 +2,8 @@ package com.monsanto.arch.cloudformation.model
 
 import spray.json._
 
+import scala.collection.immutable.ListMap
+
 /**
  * Created by bkrodg on 2/16/15.
  */
@@ -12,6 +14,6 @@ object Condition extends DefaultJsonProtocol {
       def write(obj: Condition) = obj.function.toJson
     }
 
-    def write(objs: Seq[Condition]) = JsObject( objs.map( o => o.name -> o.toJson ).toMap )
+    def write(objs: Seq[Condition]) = JsObject( ListMap(objs.map( o => o.name -> o.toJson ): _*) )
   }
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Mapping.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Mapping.scala
@@ -3,6 +3,8 @@ package com.monsanto.arch.cloudformation.model
 import spray.json._
 import DefaultJsonProtocol._
 
+import scala.collection.immutable.ListMap
+
 /**
  * Created by Ryan Richt on 2/15/15
  */
@@ -25,6 +27,6 @@ object Mapping extends DefaultJsonProtocol {
       }
     }
 
-    def write(objs: Seq[Mapping[_]]) = JsObject(objs.map(o => o.name -> format.write(o)).toMap)
+    def write(objs: Seq[Mapping[_]]) = JsObject(ListMap(objs.map(o => o.name -> format.write(o)): _*))
   }
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Output.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Output.scala
@@ -3,6 +3,8 @@ package com.monsanto.arch.cloudformation.model
 import spray.json._
 import DefaultJsonProtocol._
 
+import scala.collection.immutable.ListMap
+
 /**
  * Created by Ryan Richt on 2/15/15
  */
@@ -21,6 +23,6 @@ object Output extends DefaultJsonProtocol {
         )
     }
 
-    def write(objs: Seq[Output[_]]) = JsObject(objs.map(o => o.name -> format.write(o)).toMap)
+    def write(objs: Seq[Output[_]]) = JsObject(ListMap(objs.map(o => o.name -> format.write(o)): _*))
   }
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Parameter.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Parameter.scala
@@ -3,6 +3,7 @@ package com.monsanto.arch.cloudformation.model
 import com.monsanto.arch.cloudformation.model.resource._
 import spray.json._
 import DefaultJsonProtocol._
+import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
 
 /**
@@ -38,7 +39,7 @@ object Parameter extends DefaultJsonProtocol {
       }
     }
 
-    def write(objs: Seq[Parameter]) = JsObject( objs.map( o => o.name -> o.toJson ).toMap )
+    def write(objs: Seq[Parameter]) = JsObject( ListMap(objs.map( o => o.name -> o.toJson ): _*) )
   }
 }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
@@ -5,6 +5,7 @@ import com.monsanto.arch.cloudformation.model.simple.SecurityGroupRoutable
 import spray.json._
 import DefaultJsonProtocol._
 
+import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
@@ -114,7 +115,7 @@ object Template extends DefaultJsonProtocol {
       if(p.Mappings.nonEmpty) fields ++= productElement2Field[Option[Seq[Mapping[_]]]]("Mappings", p, 3)
       if(p.Resources.nonEmpty) fields ++= productElement2Field[Option[Seq[Resource[_]]]]("Resources", p, 4)
       if(p.Outputs.nonEmpty) fields ++= productElement2Field[Option[Seq[Output[_]]]]("Outputs", p, 6)
-      JsObject(fields: _*)
+      JsObject(ListMap(fields: _*))
     }
   }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
@@ -3,9 +3,11 @@ package com.monsanto.arch.cloudformation.model.resource
 import com.monsanto.arch.cloudformation.model._
 import spray.json._
 
+import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.NameTransformer
+
 
 /**
  * Created by Ryan Richt on 2/15/15
@@ -48,7 +50,7 @@ object Resource extends DefaultJsonProtocol {
       }
     }
 
-    def write(objs: Seq[Resource[_]]) = JsObject( objs.map( o => o.name -> format.write(o) ).toMap )
+    def write(objs: Seq[Resource[_]]) = JsObject( ListMap(objs.map( o => o.name -> format.write(o) ): _*) )
   }
 }
 


### PR DESCRIPTION
Fixes #45.

Using ListMap to hold elements, which are traversed in the same order they are added.