### PR TITLE
Fix `Fn::Not`, `Fn::And`, and `Fn::Or`

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -35,6 +35,7 @@ object AmazonFunctionCall extends DefaultJsonProtocol {
         case not: `Fn::Not`            => implicitly[JsonWriter[`Fn::Not`#CFBackingType]         ].write(not.arguments)
         case and: `Fn::And`            => implicitly[JsonWriter[`Fn::And`#CFBackingType]         ].write(and.arguments)
         case or:  `Fn::Or`             => implicitly[JsonWriter[`Fn::Or`#CFBackingType]          ].write(or.arguments)
+        case cfr:  ConditionFnRef      => implicitly[JsonWriter[ConditionFnRef#CFBackingType]    ].write(cfr.arguments)
         case s:   `Fn::Select`[_]      => s.serializeArguments
         case f:   `Fn::If`[_]          => f.serializeArguments
         case f:    If[_]               => f.serializeArguments
@@ -58,7 +59,6 @@ object ParameterRef extends DefaultJsonProtocol {
 }
 
 
-//extends AmazonFunctionCall[R]("Ref"){type CFBackingType = String ; val arguments = p.name}
 case class MappingRef[R](m: Mapping[R])
 object MappingRef extends DefaultJsonProtocol {
 
@@ -126,14 +126,17 @@ case class `Fn::Base64`(toEncode: Token[String])
 case class `Fn::Equals`(a: Token[String], b: Token[String])
   extends AmazonFunctionCall[String]("Fn::Equals"){type CFBackingType = (Token[String], Token[String]) ; val arguments = (a, b)}
 
-case class `Fn::Not`(fn: Token[ConditionRef])
-  extends AmazonFunctionCall[String]("Fn::Not"){type CFBackingType = (Seq[Token[ConditionRef]]) ; val arguments = Seq(fn)}
+case class `Fn::Not`(fn: Token[String])
+  extends AmazonFunctionCall[String]("Fn::Not"){type CFBackingType = (Seq[Token[String]]) ; val arguments = Seq(fn)}
 
-case class `Fn::And`(fn: Seq[Token[ConditionRef]])
-  extends AmazonFunctionCall[String]("Fn::And"){type CFBackingType = (Seq[Token[ConditionRef]]) ; val arguments = fn}
+case class `Fn::And`(fn: Seq[Token[String]])
+  extends AmazonFunctionCall[String]("Fn::And"){type CFBackingType = (Seq[Token[String]]) ; val arguments = fn}
 
-case class `Fn::Or`(fn: Seq[Token[ConditionRef]])
-  extends AmazonFunctionCall[String]("Fn::Or"){type CFBackingType = (Seq[Token[ConditionRef]]) ; val arguments = fn}
+case class `Fn::Or`(fn: Seq[Token[String]])
+  extends AmazonFunctionCall[String]("Fn::Or"){type CFBackingType = (Seq[Token[String]]) ; val arguments = fn}
+
+case class ConditionFnRef(c: Condition)
+  extends AmazonFunctionCall[String]("Condition"){type CFBackingType = (Token[String]) ; val arguments = StringToken(c.name)}
 
 case class `Fn::Select`[R: JsonFormat](index: Token[StringBackedInt], listOfObjects: Token[Seq[R]])
   extends AmazonFunctionCall[R]("Fn::Select") {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/ConditionFunctionNestable_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/ConditionFunctionNestable_UT.scala
@@ -1,0 +1,166 @@
+package com.monsanto.arch.cloudformation.model
+
+import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.resource._
+import org.scalatest.{FunSpec, Matchers}
+import spray.json._
+import DefaultJsonProtocol._
+/**
+ * Created by Ryan Richt on 2/26/15
+ */
+class ConditionFunctionNestable_UT extends FunSpec with Matchers {
+
+  describe("Fn::Not(Fn::Equals)"){
+
+    it("Should serialize correctly"){
+
+      val test: Token[String] = `Fn::Not`(`Fn::Equals`("hello", "there"))
+
+      val expected = JsObject(
+        "Fn::Not"-> JsArray(
+          JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there")))
+        )
+      )
+      test.toJson should be(expected)
+    }
+  }
+
+  describe("Fn::And(Fn::Equals, Fn::Equals)"){
+
+    it("Should serialize correctly"){
+
+      val test: Token[String] = `Fn::And`(Seq(
+        `Fn::Equals`("hello", "there"),
+        `Fn::Equals`("is it me", "you're looking for"))
+      )
+      val expected = JsObject(
+        "Fn::And"-> JsArray(
+          JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there"))),
+          JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+        )
+      )
+      test.toJson should be(expected)
+    }
+  }
+
+  describe("Fn::Or(Fn::Equals, Fn::Equals)"){
+
+    it("Should serialize correctly"){
+
+      val test: Token[String] = `Fn::Or`(Seq(
+        `Fn::Equals`("hello", "there"),
+        `Fn::Equals`("is it me", "you're looking for"))
+      )
+      val expected = JsObject(
+        "Fn::Or"-> JsArray(
+          JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there"))),
+          JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+        )
+      )
+      test.toJson should be(expected)
+    }
+  }
+
+
+  describe("Fn::Or(Condition, Fn::And(Fn::Equals, Fn::Equals))"){
+
+    it("Should serialize correctly"){
+      val cond = ConditionFnRef(Condition(name="blah", function = `Fn::Equals`("hello", "there")))
+
+      val test: Token[String] = `Fn::Or`(Seq(
+        cond,
+        `Fn::And`(Seq(
+          `Fn::Equals`("hello", "there"),
+          `Fn::Equals`("is it me", "you're looking for"))
+        ))
+      )
+      val expected =
+        JsObject("Fn::Or" -> JsArray(
+          JsObject("Condition" -> JsString("blah")),
+          JsObject("Fn::And"-> JsArray(
+            JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there"))),
+            JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+          )
+        ))
+      )
+      test.toJson should be(expected)
+    }
+  }
+  describe("Fn::Not(Fn::Or(Fn::Equals, Fn::Equals))"){
+
+    it("Should serialize correctly"){
+
+      val test: Token[String] = `Fn::Not`(`Fn::Or`(Seq(
+        `Fn::Equals`("hello", "there"),
+        `Fn::Equals`("is it me", "you're looking for"))
+      ))
+      val expected = JsObject("Fn::Not" -> JsArray(
+        JsObject(
+          "Fn::Or"-> JsArray(
+            JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there"))),
+            JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+          )
+        )
+      ))
+      test.toJson should be(expected)
+    }
+  }
+
+  describe("Fn::Not(Fn::And(Fn::Equals, Fn::Equals))"){
+
+    it("Should serialize correctly"){
+
+      val test: Token[String] = `Fn::Not`(`Fn::And`(Seq(
+        `Fn::Equals`("hello", "there"),
+        `Fn::Equals`("is it me", "you're looking for"))
+      ))
+      val expected = JsObject("Fn::Not" -> JsArray(
+        JsObject(
+          "Fn::And"-> JsArray(
+            JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there"))),
+            JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+          )
+        )
+      ))
+      test.toJson should be(expected)
+    }
+  }
+
+  describe("Fn::Or(Condition, Fn::Equals)"){
+
+    it("Should serialize correctly"){
+
+      val cond = ConditionFnRef(Condition(name="blah", function = `Fn::Equals`("hello", "there")))
+      val test: Token[String] = `Fn::Or`(Seq(
+        cond,
+        `Fn::Equals`("is it me", "you're looking for"))
+      )
+      val expected = JsObject(
+        "Fn::Or"-> JsArray(
+          JsObject("Condition" -> JsString("blah")),
+          JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+        )
+      )
+      test.toJson should be(expected)
+    }
+  }
+
+  describe("Fn::And(Condition, Fn::Equals)"){
+
+    it("Should serialize correctly"){
+
+      val cond = ConditionFnRef(Condition(name="blah", function = `Fn::Equals`("hello", "there")))
+      val test: Token[String] = `Fn::And`(Seq(
+        cond,
+        `Fn::Equals`("is it me", "you're looking for"))
+      )
+      val expected = JsObject(
+        "Fn::And"-> JsArray(
+          JsObject("Condition" -> JsString("blah")),
+          JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+        )
+      )
+      test.toJson should be(expected)
+    }
+  }
+}


### PR DESCRIPTION
Rolls back a portion of https://github.com/MonsantoCo/cloudformation-template-generator/pull/57 to fix https://github.com/MonsantoCo/cloudformation-template-generator/issues/60.  This only fixes it in the sense that it works again and adds unit tests for the cases that #57 broke.  I'll leave #60 open as we'd like to add better type safety as was intended.  However, I'm running into issues with getting it to work with all the implicits involved in the `AmazonFunctionCall` and `Token` conversions, and I need to move on for now.