### PR TITLE
Add VPNGateway support to EC2 Route Resource

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EC2.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EC2.scala
@@ -264,11 +264,13 @@ object Protocol {
 @implicitNotFound("A Route can only have exactly ONE of GatewayId, InstanceId, NetworkInterfaceId or VpcPeeringConnectionId set")
 sealed trait ValidRouteComboOption
 case class InternetGatewayRoute(v:Token[ResourceRef[`AWS::EC2::InternetGateway`]]) extends ValidRouteComboOption
+case class VPNGatewayRoute(v:Token[ResourceRef[`AWS::EC2::VPNGateway`]]) extends ValidRouteComboOption
 case class EC2InstanceRoute(v:Token[ResourceRef[`AWS::EC2::Instance`]]) extends ValidRouteComboOption
 case class VPCPeeringRoute(v:Token[ResourceRef[`AWS::EC2::VPCPeeringConnection`]]) extends ValidRouteComboOption
 
 object ValidRouteComboOption {
   implicit def toInternetGateway[T](v: T)(implicit t:T => Token[ResourceRef[`AWS::EC2::InternetGateway`]]) = InternetGatewayRoute(v)
+  implicit def toVPNGateway[T](v: T)(implicit t:T => Token[ResourceRef[`AWS::EC2::VPNGateway`]]) = VPNGateway(v)
   implicit def toEC2InstanceRoute[T](v:T)(implicit t :T => Token[ResourceRef[`AWS::EC2::Instance`]]) = EC2InstanceRoute(v)
   implicit def toVPCPeeringRoute[T](v:T)(implicit t :T => Token[ResourceRef[`AWS::EC2::VPCPeeringConnection`]]) = VPCPeeringRoute(v)
 }
@@ -277,17 +279,18 @@ class `AWS::EC2::Route` private (
   val name:                   String,
   val RouteTableId:           Token[ResourceRef[`AWS::EC2::RouteTable`]],
   val DestinationCidrBlock:   Token[CidrBlock],
-  val GatewayId:              Option[Token[ResourceRef[`AWS::EC2::InternetGateway`]]] = None,
+  val InternetGatewayId:      Option[Token[ResourceRef[`AWS::EC2::InternetGateway`]]] = None,
+  val VPNGatewayId:           Option[Token[ResourceRef[`AWS::EC2::VPNGateway`]]] = None,
   val InstanceId:             Option[Token[ResourceRef[`AWS::EC2::Instance`]]] = None,
   val VpcPeeringConnectionId: Option[Token[ResourceRef[`AWS::EC2::VPCPeeringConnection`]]] = None,
   override val Condition:     Option[ConditionRef] = None,
   override val DependsOn:     Option[Seq[String]] = None
 ) extends Resource[`AWS::EC2::Route`] {
-  private val asSeq = Seq(name, RouteTableId, DestinationCidrBlock, GatewayId, InstanceId, VpcPeeringConnectionId,
+  private val asSeq = Seq(name, RouteTableId, DestinationCidrBlock, InternetGatewayId, VPNGatewayId, InstanceId, VpcPeeringConnectionId,
     Condition, DependsOn)
 
   def when(newCondition: Option[ConditionRef] = Condition) =
-    new `AWS::EC2::Route`(name, RouteTableId, DestinationCidrBlock, GatewayId, InstanceId, VpcPeeringConnectionId,
+    new `AWS::EC2::Route`(name, RouteTableId, DestinationCidrBlock, InternetGatewayId, VPNGatewayId, InstanceId, VpcPeeringConnectionId,
       newCondition, DependsOn)
 }
 object `AWS::EC2::Route` extends DefaultJsonProtocol {
@@ -308,12 +311,18 @@ object `AWS::EC2::Route` extends DefaultJsonProtocol {
           "name"                   -> writeField(p.name),
           "RouteTableId"           -> writeField(p.RouteTableId),
           "DestinationCidrBlock"   -> writeField(p.DestinationCidrBlock),
-          "GatewayId"              -> writeField(p.GatewayId),
+          "InternetGatewayId"      -> writeField(p.InternetGatewayId),
+          "VPNGatewayId"           -> writeField(p.VPNGatewayId),
           "InstanceId"             -> writeField(p.InstanceId),
           "VpcPeeringConnectionId" -> writeField(p.VpcPeeringConnectionId),
           "Condition"              -> writeField(p.Condition),
           "DependsOn"              -> writeField(p.DependsOn)
-        ).filter(_._2.isDefined).mapValues(_.get)
+        ).filter(_._2.isDefined).map{ case (k, v) =>
+          val nk = if (k == "VPNGatewayId" || k == "InternetGatewayId")
+            "GatewayId"
+          else k
+          nk -> v.get
+        }
       )
     }
 
@@ -331,11 +340,13 @@ object `AWS::EC2::Route` extends DefaultJsonProtocol {
            ) =
     connectionBobber match {
       case InternetGatewayRoute(v) => new `AWS::EC2::Route`(name, RouteTableId, DestinationCidrBlock,
-        Some(v), None,None, Condition, DependsOn)
+        Some(v), None, None, None, Condition, DependsOn)
+      case VPNGatewayRoute(v)      => new `AWS::EC2::Route`(name, RouteTableId, DestinationCidrBlock,
+        None, Some(v), None, None, Condition, DependsOn)
       case EC2InstanceRoute(v)     => new `AWS::EC2::Route`(name, RouteTableId, DestinationCidrBlock,
-        None, Some(v), None, Condition, DependsOn)
+        None, None, Some(v), None, Condition, DependsOn)
       case VPCPeeringRoute(v)      => new `AWS::EC2::Route`(name, RouteTableId, DestinationCidrBlock,
-        None, None ,Some(v), Condition, DependsOn)
+        None, None, None, Some(v), Condition, DependsOn)
     }
 }
 


### PR DESCRIPTION
AWS decided to overload the [GatewayId](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html#cfn-ec2-route-gatewayid) with two resource gateways options; Internet and VPN. I've created this PR with a possible implementation but it doesn't feel clean. Do you think there is a better way?

I tried to go down the route of applying a trait "Gateway" to both Internet and VPN resources and then put an upper bounded type limit on the Route resource class gateway parameter but alas, I was over my head in scala type knowledge. 

Appreciate any feedback
