### PR TITLE
Add support for nesting a Fn::Not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.3.1] - 2015-03-30
+
+### Changed
+
+-   Modified Fn::Not to be a NestableAmazonFunctionCall to support using the function within an Fn::And block
+
 ## [3.3.0] - 2015-03-18
 
 **Note: This breaks backwards compatibility for anyone using custom NAT Gateways.**

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -136,7 +136,7 @@ case class `Fn::Equals`(a: Token[String], b: Token[String])
 {type CFBackingType = (Token[String], Token[String]) ; val arguments = (a, b)}
 
 case class `Fn::Not`(fn: ConditionFunctionNestable[String])
-  extends AmazonFunctionCall[String]("Fn::Not"){type CFBackingType = (Seq[Token[String]]) ; val arguments = Seq(fn).map(_.token)}
+  extends NestableAmazonFunctionCall[String]("Fn::Not"){type CFBackingType = (Seq[Token[String]]) ; val arguments = Seq(fn).map(_.token)}
 
 case class `Fn::And`(fn: Seq[ConditionFunctionNestable[String]])
   extends NestableAmazonFunctionCall[String]("Fn::And"){type CFBackingType = (Seq[Token[String]]) ; val arguments = fn.map(_.token)}

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/ConditionFunctionNestable_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/ConditionFunctionNestable_UT.scala
@@ -163,4 +163,24 @@ class ConditionFunctionNestable_UT extends FunSpec with Matchers {
       test.toJson should be(expected)
     }
   }
+
+  describe("Fn::And(Fn::Not(Fn::Equals), Fn::Equals)"){
+
+    it("Should serialize correctly"){
+
+      val test: Token[String] = `Fn::And`(Seq(
+        `Fn::Not`(`Fn::Equals`("hello", "there")),
+        `Fn::Equals`("is it me", "you're looking for"))
+      )
+      val expected = JsObject(
+        "Fn::And"-> JsArray(
+          JsObject("Fn::Not" -> JsArray(
+            JsObject("Fn::Equals" -> JsArray(JsString("hello"), JsString("there"))))
+          ),
+          JsObject("Fn::Equals" -> JsArray(JsString("is it me"), JsString("you're looking for")))
+        )
+      )
+      test.toJson should be(expected)
+    }
+  }
 }


### PR DESCRIPTION
I ran into a case where I needed to do something like: Fn::And(Fn::Not(Fn::Equal), Fn:Equal). This wasn't currently supported. I'm guessing we just missed it with https://github.com/MonsantoCo/cloudformation-template-generator/issues/60 and https://github.com/MonsantoCo/cloudformation-template-generator/pull/66 . I don't think this should have any affect on legacy code.