### PR TITLE
Parameterized VPC and security group for RDS

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Parameter.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Parameter.scala
@@ -33,6 +33,7 @@ object Parameter extends DefaultJsonProtocol {
           case k:  `AWS::EC2::KeyPair::KeyName_Parameter`   => k.toJson
           case v:  `AWS::EC2::VPC_Parameter`                => v.toJson
           case e:  `AWS::RDS::DBInstance::Engine_Parameter` => e.toJson
+          case s:  `AWS::RDS::DBSubnetGroup_Parameter`      => s.toJson
         }
 
         JsObject( raw.asJsObject.fields - "name" - "ConfigDefault" + ("Type" -> JsString(obj.Type)) )
@@ -181,7 +182,7 @@ case class `AWS::EC2::VPC_Parameter`(
                                       Description:   Option[String],
                                       Default:       Option[Token[ResourceRef[`AWS::EC2::VPC`]]] = None,
                                       ConfigDefault: Option[String] = None
-                                      ) extends Parameter("String"){type Rep = ResourceRef[`AWS::EC2::VPC`]}
+                                      ) extends Parameter("AWS::EC2::VPC::Id"){type Rep = ResourceRef[`AWS::EC2::VPC`]}
 object `AWS::EC2::VPC_Parameter` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::EC2::VPC_Parameter`] = jsonFormat4(`AWS::EC2::VPC_Parameter`.apply)
 }
@@ -194,6 +195,15 @@ case class `AWS::RDS::DBInstance::Engine_Parameter`(
                                                      ) extends Parameter("String"){type Rep = `AWS::RDS::DBInstance::Engine`}
 object `AWS::RDS::DBInstance::Engine_Parameter` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::RDS::DBInstance::Engine_Parameter`] = jsonFormat4(`AWS::RDS::DBInstance::Engine_Parameter`.apply)
+}
+
+case class `AWS::RDS::DBSubnetGroup_Parameter`(name:          String,
+                                               Description:   Option[String],
+                                               Default:       Option[String] = None,
+                                               ConfigDefault: Option[String] = None
+                                              ) extends Parameter("String"){type Rep = ResourceRef[`AWS::RDS::DBSubnetGroup`]}
+object `AWS::RDS::DBSubnetGroup_Parameter` extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[`AWS::RDS::DBSubnetGroup_Parameter`] = jsonFormat4(`AWS::RDS::DBSubnetGroup_Parameter`.apply)
 }
 
 case class InputParameter(ParameterKey: String, ParameterValue: JsValue = "<changeMe>".toJson)
@@ -234,5 +244,8 @@ object InputParameter extends DefaultJsonProtocol {
       case `AWS::RDS::DBInstance::Engine_Parameter`(n, _, _, Some(d)) => InputParameter(n, d.toJson)
       case `AWS::RDS::DBInstance::Engine_Parameter`(n, _, Some(d), None) => InputParameter(n, d.toJson)
       case `AWS::RDS::DBInstance::Engine_Parameter`(n, _, None, None) => InputParameter(n)
+      case `AWS::RDS::DBSubnetGroup_Parameter`(n, None, _, _) => InputParameter(n)
+      case `AWS::RDS::DBSubnetGroup_Parameter`(n, Some(d), None, _) => InputParameter(n, d.toJson)
+      case `AWS::RDS::DBSubnetGroup_Parameter`(n, _, Some(d), _) => InputParameter(n, d.toJson)
     }))
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/RDS.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/RDS.scala
@@ -64,7 +64,7 @@ case class `AWS::RDS::DBInstance` private[resource] (
   DBParameterGroupName:        Option[ResourceRef[`AWS::RDS::DBParameterGroup`]],
   DBSecurityGroups:            Option[Seq[ResourceRef[`AWS::RDS::DBSecurityGroup`]]],
   DBSnapshotIdentifier:        Option[String],
-  DBSubnetGroupName:           Option[ResourceRef[`AWS::RDS::DBSubnetGroup`]],
+  DBSubnetGroupName:           Option[Token[ResourceRef[`AWS::RDS::DBSubnetGroup`]]],
   Engine:                      Option[Token[`AWS::RDS::DBInstance::Engine`]],
   EngineVersion:               Option[String],
   Iops:                        Option[Either[Int, Token[Int]]],
@@ -141,7 +141,7 @@ sealed trait RdsLocation {
   * @param vpcSecurityGroups AWS::RDS::DBInstance(VPCSecurityGroups)
   */
 case class RdsVpc(
-  dbSubnetGroupName:   ResourceRef[`AWS::RDS::DBSubnetGroup`],
+  dbSubnetGroupName:   Token[ResourceRef[`AWS::RDS::DBSubnetGroup`]],
   vpcSecurityGroups:   Option[Seq[ResourceRef[`AWS::EC2::SecurityGroup`]]] = None
 ) extends RdsLocation {
   private[resource] def location(rdsInstance: `AWS::RDS::DBInstance`): `AWS::RDS::DBInstance` =
@@ -150,6 +150,7 @@ case class RdsVpc(
       DBSubnetGroupName = Some(dbSubnetGroupName),
       VPCSecurityGroups = vpcSecurityGroups
     )
+
 }
 
 /** RDS instance not in a VPC, a "classic".
@@ -557,7 +558,7 @@ case class `AWS::RDS::DBSecurityGroup`(
   name:                   String,
   DBSecurityGroupIngress: Seq[RDSDBSecurityGroupRule],
   GroupDescription:       String,
-  EC2VpcId:               Option[ResourceRef[`AWS::EC2::VPC`]] = None,
+  EC2VpcId:               Option[Token[ResourceRef[`AWS::EC2::VPC`]]] = None,
   Tags:                   Option[Seq[AmazonTag]]               = None,
   override val Condition: Option[ConditionRef]                 = None
 ) extends Resource[`AWS::RDS::DBSecurityGroup`]{

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
@@ -69,7 +69,7 @@ class RDS_UT extends FunSpec with Matchers {
       val dbSubnetGroupParamName = "dbSubnetGroup"
       val dbSubnetGroupParam = `AWS::RDS::DBSubnetGroup_Parameter`(dbSubnetGroupParamName , "Subnet group where RDS instances are created.")
       val rdsInstanceWithSubnetParam = rdsInstance.copy(DBSubnetGroupName = Some(ParameterRef(dbSubnetGroupParam)))
-      val expected = JsObject(
+      val expectedInstanceJson = JsObject(
         "TestRds" -> JsObject(
           "Type" -> JsString("AWS::RDS::DBInstance"),
           "Properties" -> JsObject(
@@ -85,7 +85,14 @@ class RDS_UT extends FunSpec with Matchers {
           )
         )
       )
-      Seq[Resource[_]](rdsInstanceWithSubnetParam).toJson should be (expected)
+      val expectedSubnetGroupParamJson = JsObject(
+        "dbSubnetGroup" -> JsObject(
+          "Description" -> JsString("Subnet group where RDS instances are created."),
+          "Type" -> JsString("String")
+        )
+      )
+      Seq[Resource[_]](rdsInstanceWithSubnetParam).toJson should be (expectedInstanceJson)
+      Seq[Parameter](dbSubnetGroupParam).toJson should be (expectedSubnetGroupParamJson)
     }
 
     it("should create a valid new RDS database instance when EC2VpcId is passed in as a parameter") {


### PR DESCRIPTION
DBSubnetGroupName and EC2VpcId can now be passed as ParameterRef