### PR TITLE
Add AWS/Lambda CloudWatch Alarm Namespace

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudWatch.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudWatch.scala
@@ -63,6 +63,7 @@ object `AWS::CloudWatch::Alarm::Namespace` extends DefaultJsonProtocol {
   case object `AWS/EC2`              extends `AWS::CloudWatch::Alarm::Namespace`
   case object `AWS/ELB`              extends `AWS::CloudWatch::Alarm::Namespace`
   case object `AWS/ElasticMapReduce` extends `AWS::CloudWatch::Alarm::Namespace`
+  case object `AWS/Lambda`           extends `AWS::CloudWatch::Alarm::Namespace`
   case object `AWS/Kinesis`          extends `AWS::CloudWatch::Alarm::Namespace`
   case object `AWS/OpsWorks`         extends `AWS::CloudWatch::Alarm::Namespace`
   case object `AWS/Redshift`         extends `AWS::CloudWatch::Alarm::Namespace`
@@ -89,7 +90,8 @@ object `AWS::CloudWatch::Alarm::Namespace` extends DefaultJsonProtocol {
     `AWS/SNS`,
     `AWS/SQS`,
     `AWS/SWF`,
-    `AWS/StorageGateway`
+    `AWS/StorageGateway`,
+    `AWS/Lambda`
   )
   implicit val format: JsonFormat[`AWS::CloudWatch::Alarm::Namespace`] =
     new EnumFormat[`AWS::CloudWatch::Alarm::Namespace`](values)


### PR DESCRIPTION
Amazon added Lambda CloudWatch alarms. This PR adds the namespace to the `AWS::CloudWatch::Alarm::Namespace` enum. See [http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/lam-metricscollected.html#lambda-cloudwatch-metrics]() for reference on the namespace.