### PR TITLE
Add Version attribute to IAM Document

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -205,7 +205,7 @@ case class Policy(PolicyName: String, PolicyDocument: PolicyDocument)
 object Policy extends DefaultJsonProtocol {
   implicit val format: JsonFormat[Policy] = jsonFormat2(Policy.apply)
 }
-case class PolicyDocument(Statement: Seq[PolicyStatement])
+case class PolicyDocument(Statement: Seq[PolicyStatement], Version : Option[String] = None)
 object PolicyDocument extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[PolicyDocument] = jsonFormat1(PolicyDocument.apply)
+  implicit val format: JsonFormat[PolicyDocument] = jsonFormat2(PolicyDocument.apply)
 }


### PR DESCRIPTION
Version defaults to 2008-10-17, but some cloudformation directives
require '2012-10-17', such as AWS::IAM::ManagedPolicy

http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Version