### PR TITLE
[#97] Make AWS::Lambda::Function#Description Option[Token[String]]

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Lambda.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Lambda.scala
@@ -27,7 +27,7 @@ object Runtime {
 
 case class `AWS::Lambda::Function`(name: String,
                                    Code: Code,
-                                   Description: Option[String],
+                                   Description: Option[Token[String]],
                                    Handler: String,
                                    Runtime: Runtime,
                                    MemorySize: Option[Token[Int]] = None,


### PR DESCRIPTION
Fix for #97 makes the Description property an `Option[Token[String]]`