### PR TITLE
Add "DependsOn" to AWS::DynamoDb::Table

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDB.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDB.scala
@@ -20,7 +20,8 @@ case class `AWS::DynamoDB::Table`(
                                    StreamSpecification : Option[StreamSpecification] = None,
                                    TableName: Token[String],
                                    override val Condition: Option[ConditionRef] = None,
-                                   override val DeletionPolicy: Option[DeletionPolicy] = None
+                                   override val DeletionPolicy: Option[DeletionPolicy] = None,
+                                   override val DependsOn: Option[Seq[String]] = None
                                  ) extends Resource[`AWS::DynamoDB::Table`] with HasArn {
 
   override def arn = aws"arn:aws:dynamodb:${`AWS::Region`}:${`AWS::AccountId`}:table/${ResourceRef(this)}"
@@ -34,7 +35,7 @@ case class `AWS::DynamoDB::Table`(
 }
 
 object `AWS::DynamoDB::Table` {
-  implicit val format: JsonFormat[`AWS::DynamoDB::Table`] = jsonFormat10(`AWS::DynamoDB::Table`.apply)
+  implicit val format: JsonFormat[`AWS::DynamoDB::Table`] = jsonFormat11(`AWS::DynamoDB::Table`.apply)
 }
 
 sealed abstract class StreamViewType(val name : String)

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/DynamoDBSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/DynamoDBSpec.scala
@@ -41,7 +41,8 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
         WriteCapacityUnits = 1
       ),
       TableName = "Table1",
-      DeletionPolicy = Some(Retain)
+      DeletionPolicy = Some(Retain),
+      DependsOn = Some(Seq("myothertable"))
     )
     val resource: Resource[`AWS::DynamoDB::Table`] = dynamoDbTable
 
@@ -50,6 +51,7 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
         |{
         | "Type": "AWS::DynamoDB::Table",
         | "DeletionPolicy" : "Retain",
+        | "DependsOn": ["myothertable"],
         | "Properties": {
         | "LocalSecondaryIndexes":[
         |   {


### PR DESCRIPTION
CloudFormation will make a maximum of ten tables at one time. Making more than that requires chaining them together with "DependsOn" attributes.