### PR TITLE
add support for Fn::Split

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model.{ConditionRef, ResourceRef, Token, `Fn::GetAtt`}
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 import DefaultJsonProtocol._
 
@@ -219,7 +220,7 @@ case class `AWS::ApiGateway::RestApi`(
                                        CloneFrom: Option[Token[String]] = None,
                                        Description: Option[String] = None,
                                        FailOnWarnings: Option[Boolean] = None,
-                                       Parameters: Option[Seq[Token[String]]] = None,
+                                       Parameters: Option[TokenSeq[String]] = None,
                                        override val Condition: Option[ConditionRef] = None
                                      ) extends Resource[`AWS::ApiGateway::RestApi`] {
   override def when(newCondition: Option[ConditionRef]) = copy(Condition = newCondition)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json._
 
 /**
@@ -9,7 +10,7 @@ import spray.json._
 
 case class `AWS::AutoScaling::AutoScalingGroup`(
     name:                    String,
-    AvailabilityZones:       Seq[Token[String]],
+    AvailabilityZones:       TokenSeq[String],
     LaunchConfigurationName: Token[ResourceRef[`AWS::AutoScaling::LaunchConfiguration`]],
     MinSize:                 StringBackedInt,
     MaxSize:                 StringBackedInt,
@@ -129,7 +130,7 @@ case class AutoScalingRollingUpdate(
     MaxBatchSize: Option[Token[Int]] = None,
     MinInstancesInService: Option[Token[Int]] = None,
     PauseTime: Option[Token[String]] = None,
-    SuspendProcesses: Option[Seq[Token[String]]] = None,
+    SuspendProcesses: Option[TokenSeq[String]] = None,
     WaitOnResourceSignals: Option[Token[Boolean]] = None)
 
 object AutoScalingRollingUpdate extends DefaultJsonProtocol {

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
@@ -1,5 +1,6 @@
 package com.monsanto.arch.cloudformation.model.resource
 
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import com.monsanto.arch.cloudformation.model._
 import spray.json.JsonFormat
 
@@ -42,7 +43,7 @@ case class `AWS::CloudFormation::Stack`(name: String,
                                         TemplateURL: Token[String],
                                         TimeoutInMinutes: Option[StringBackedInt] = None,
                                         Parameters: Option[Map[String, Token[String]]] = None,
-                                        NotificationARNs: Option[Seq[Token[String]]] = None,
+                                        NotificationARNs: Option[TokenSeq[String]] = None,
                                         override val Condition: Option[ConditionRef] = None)
     extends Resource[`AWS::CloudFormation::Stack`]
     with HasArn {

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudWatch.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudWatch.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json._
 
 /**
@@ -19,12 +20,12 @@ case class `AWS::CloudWatch::Alarm`(
   Statistic:               `AWS::CloudWatch::Alarm::Statistic`,
   Threshold:               String, //BackedInt,
   ActionsEnabled:          Option[Boolean] = None,
-  AlarmActions:            Option[Seq[Token[String]]] = None,
+  AlarmActions:            Option[TokenSeq[String]] = None,
   AlarmDescription:        Option[String] = None,
   AlarmName:               Option[Token[String]] = None,
   Dimensions:              Option[Seq[`AWS::CloudWatch::Alarm::Dimension`]] = None,
-  InsufficientDataActions: Option[Seq[Token[String]]] = None,
-  OKActions:               Option[Seq[Token[String]]] = None,
+  InsufficientDataActions: Option[TokenSeq[String]] = None,
+  OKActions:               Option[TokenSeq[String]] = None,
   Unit:                    Option[`AWS::CloudWatch::Alarm::Unit`] = None,
   override val Condition: Option[ConditionRef] = None
   ) extends Resource[`AWS::CloudWatch::Alarm`]{

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EMR.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EMR.scala
@@ -1,13 +1,14 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model.{ConditionRef, Token}
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json.{DefaultJsonProtocol, JsObject, JsValue, JsonFormat, RootJsonFormat}
 import DefaultJsonProtocol._
 
 
 case class Application(
                         AdditionalInfo: Option[Map[String, Token[String]]],
-                        Args: Option[Seq[Token[String]]],
+                        Args: Option[TokenSeq[String]],
                         Name: Option[Token[String]],
                         Version: Option[Token[String]]
                       )
@@ -16,7 +17,7 @@ object Application {
   implicit val format = jsonFormat4(Application.apply)
 }
 
-case class ScriptBootstrapAction(Args: Option[Seq[Token[String]]], Path: Token[String])
+case class ScriptBootstrapAction(Args: Option[TokenSeq[String]], Path: Token[String])
 object ScriptBootstrapAction {
   implicit val format = jsonFormat2(ScriptBootstrapAction.apply)
 }
@@ -83,8 +84,8 @@ object PlacementType {
   implicit val format = jsonFormat1(PlacementType.apply)
 }
 
-case class JobFlowInstancesConfig(AdditionalMasterSecurityGroups: Option[Seq[Token[String]]],
-                                  AdditionalSlaveSecurityGroups: Option[Seq[Token[String]]],
+case class JobFlowInstancesConfig(AdditionalMasterSecurityGroups: Option[TokenSeq[String]],
+                                  AdditionalSlaveSecurityGroups: Option[TokenSeq[String]],
                                   CoreInstanceGroup: InstanceGroupConfig,
                                   Ec2KeyName: Option[Token[String]],
                                   Ec2SubnetId: Option[Token[String]],
@@ -139,7 +140,7 @@ object `AWS::EMR::Step` {
   implicit val format: RootJsonFormat[`AWS::EMR::Step`] = jsonFormat7(`AWS::EMR::Step`.apply)
 }
 
-case class HadoopJarStep(Args: Option[Seq[Token[String]]], Jar: Token[String], MainClass: Option[Token[String]], StepProperties: Option[StepProperties])
+case class HadoopJarStep(Args: Option[TokenSeq[String]], Jar: Token[String], MainClass: Option[Token[String]], StepProperties: Option[StepProperties])
 
 object HadoopJarStep {
   implicit val format: RootJsonFormat[HadoopJarStep] = jsonFormat4(HadoopJarStep.apply)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElastiCache.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElastiCache.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model.{ConditionRef, EnumFormat, ResourceRef, StringBackedInt, Token}
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json._
 
 /**
@@ -90,13 +91,13 @@ case class `AWS::ElastiCache::CacheCluster`(
   NotificationTopicArn :      Option[Token[String]]                                           = None,
   Port:                       Option[Token[Int]]                                              = None,
   PreferredAvailabilityZone : Option[Token[String]]                                           = None,
-  PreferredAvailabilityZones: Option[Token[Seq[String]]]                                      = None,
+  PreferredAvailabilityZones: Option[TokenSeq[String]]                                        = None,
   PreferredMaintenanceWindow: Option[Token[String]]                                           = None,
   SnapshotArns:               Option[Token[Seq[String]]]                                      = None,
   SnapshotName:               Option[Token[String]]                                           = None,
   SnapshotRetentionLimit:     Option[Token[Int]]                                              = None,
   SnapshotWindow:             Option[Token[String]]                                           = None,
-  VpcSecurityGroupIds:        Option[Seq[Token[String]]]                                      = None,
+  VpcSecurityGroupIds:        Option[TokenSeq[String]]                                        = None,
   Tags:                       Option[Seq[AmazonTag]]                                          = None,
   override val Condition:     Option[ConditionRef]                                            = None
   ) extends Resource[`AWS::ElastiCache::CacheCluster`] {

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticLoadBalancing.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticLoadBalancing.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json._
 
 /**
@@ -15,7 +16,7 @@ case class `AWS::ElasticLoadBalancing::LoadBalancer` private (
   Listeners:                 Seq[ELBListener],
   AccessLoggingPolicy:       Option[ELBAccessLoggingPolicy],
   AppCookieStickinessPolicy: Option[ELBAppCookieStickinessPolicy],
-  AvailabilityZones:         Seq[Token[String]],
+  AvailabilityZones:         TokenSeq[String],
   ConnectionDrainingPolicy:  Option[ELBConnectionDrainingPolicy],
   ConnectionSettings:        Option[ELBConnectionSettings],
   CrossZone:                 Option[Boolean],
@@ -126,7 +127,7 @@ object `AWS::ElasticLoadBalancing::LoadBalancer` extends DefaultJsonProtocol {
     Listeners:                 Seq[ELBListener],
     AccessLoggingPolicy:       Option[ELBAccessLoggingPolicy]                     = None,
     AppCookieStickinessPolicy: Option[ELBAppCookieStickinessPolicy]               = None,
-    AvailabilityZones:         Seq[Token[String]]                                 = Seq.empty,
+    AvailabilityZones:         TokenSeq[String]                                   = Seq.empty,
     ConnectionDrainingPolicy:  Option[ELBConnectionDrainingPolicy]                = None,
     ConnectionSettings:        Option[ELBConnectionSettings]                      = None,
     CrossZone:                 Option[Boolean]                                    = None,
@@ -220,7 +221,7 @@ case class ELBListener(
   LoadBalancerPort: String,
   Protocol:         ELBListenerProtocol,
   InstanceProtocol: Option[ELBListenerProtocol] = Some(ELBListenerProtocol.HTTP),
-  PolicyNames:      Seq[Token[String]] = Seq.empty,
+  PolicyNames:      TokenSeq[String] = Seq.empty,
   SSLCertificateId: Option[Token[String]] = None
 )
 object ELBListener extends DefaultJsonProtocol {

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json._
 
 import scala.annotation.implicitNotFound
@@ -125,7 +126,7 @@ sealed trait PolicyConditionValue
 case class ListPolicyConditionValue(values : Seq[String]) extends PolicyConditionValue
 case class SimplePolicyConditionValue(value : String) extends PolicyConditionValue
 case class TokenPolicyConditionValue(value : Token[String]) extends PolicyConditionValue
-case class TokenListPolicyConditionValue(value : Seq[Token[String]]) extends PolicyConditionValue
+case class TokenListPolicyConditionValue(value : TokenSeq[String]) extends PolicyConditionValue
 
 object PolicyConditionValue extends DefaultJsonProtocol {
   implicit object format extends JsonFormat[PolicyConditionValue] {
@@ -221,7 +222,7 @@ object PolicyPrincipal extends DefaultJsonProtocol {
     def read(json: JsValue) = ???
   }
 }
-case class DefinedPrincipal(targets: Map[String, Seq[Token[String]]]) extends PolicyPrincipal
+case class DefinedPrincipal(targets: Map[String, TokenSeq[String]]) extends PolicyPrincipal
 case object WildcardPrincipal extends PolicyPrincipal
 
 case class Policy(PolicyName: String, PolicyDocument: PolicyDocument)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Lambda.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Lambda.scala
@@ -1,8 +1,9 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
-import spray.json.{JsString, JsValue, JsonFormat, DefaultJsonProtocol}
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat}
 import DefaultJsonProtocol._
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 
 class Runtime(val runtime: String)
 
@@ -60,7 +61,7 @@ object LambdaEnvironment {
   implicit val format : JsonFormat[LambdaEnvironment] = jsonFormat1(LambdaEnvironment.apply)
 }
 
-case class LambdaVpcConfig(SecurityGroupIds : Seq[Token[String]], SubnetIds : Seq[Token[String]])
+case class LambdaVpcConfig(SecurityGroupIds : TokenSeq[String], SubnetIds : TokenSeq[String])
 
 object LambdaVpcConfig {
   implicit val format : JsonFormat[LambdaVpcConfig] = jsonFormat2(LambdaVpcConfig.apply)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Route53.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Route53.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import spray.json._
 
 /**
@@ -13,7 +14,7 @@ sealed trait Route53RecordSetBaseFields {
   def RecordType:      Route53RecordType
   def HostedZoneName:  Option[Token[String]]
   def HostedZoneId:    Option[Token[String]]
-  def ResourceRecords: Option[Seq[Token[String]]]
+  def ResourceRecords: Option[TokenSeq[String]]
   def TTL:             Option[Token[String]]
   def AliasTarget:     Option[Route53AliasTarget]
   def Condition: Option[ConditionRef]
@@ -51,7 +52,7 @@ class `AWS::Route53::RecordSet` protected (
   val RecordType:      Route53RecordType,
   val HostedZoneName:  Option[Token[String]], // The parent domain, with a . after it.  Must be route 53 managed already.
   val HostedZoneId:    Option[Token[String]], // the id of the hosted zone
-  val ResourceRecords: Option[Seq[Token[String]]] = None,
+  val ResourceRecords: Option[TokenSeq[String]] = None,
   val TTL:             Option[Token[String]] = None,
   val AliasTarget:     Option[Route53AliasTarget] = None,
   override val Condition: Option[ConditionRef] = None
@@ -77,7 +78,7 @@ object `AWS::Route53::RecordSet` extends DefaultJsonProtocol {
       RecordName:      Token[String], // The subdomain, with a . after it.
       RecordType:      Route53RecordType,
       HostedZoneName:  Token[String], // The parent domain, with a . after it.  Must be route 53 managed already.
-      ResourceRecords: Seq[Token[String]],
+      ResourceRecords: TokenSeq[String],
       TTL:             Token[String],
       Condition:       Option[ConditionRef] = None
     ) = new `AWS::Route53::RecordSet`(name, RecordName, RecordType, Some(HostedZoneName), None, Some(ResourceRecords), Some(TTL), Condition = Condition)
@@ -87,7 +88,7 @@ object `AWS::Route53::RecordSet` extends DefaultJsonProtocol {
                      RecordName:      Token[String], // The subdomain, with a . after it.
                      RecordType:      Route53RecordType,
                      HostedZoneID:    Token[String], 
-                     ResourceRecords: Seq[Token[String]],
+                     ResourceRecords: TokenSeq[String],
                      TTL:             Token[String],
                      Condition:       Option[ConditionRef] = None
      ) = new `AWS::Route53::RecordSet`(name, RecordName, RecordType, None, Some(HostedZoneID), Some(ResourceRecords), Some(TTL), Condition = Condition)
@@ -110,7 +111,7 @@ class `Custom::RemoteRoute53RecordSet` private(
                                           val RecordType:      Route53RecordType,
                                           val HostedZoneName:  Option[Token[String]], // The parent domain, with a . after it.  Must be route 53 managed already.
                                           val HostedZoneId:    Option[Token[String]], // the id of the hosted zone
-                                          val ResourceRecords: Option[Seq[Token[String]]] = None,
+                                          val ResourceRecords: Option[TokenSeq[String]] = None,
                                           val TTL:             Option[Token[String]] = None,
                                           val AliasTarget:     Option[Route53AliasTarget] = None,
                                           override val Condition: Option[ConditionRef] = None
@@ -145,7 +146,7 @@ object `Custom::RemoteRoute53RecordSet` {
                      RecordName:      Token[String], // The subdomain, with a . after it.
                      RecordType:      Route53RecordType,
                      HostedZoneName:  Token[String], // The parent domain, with a . after it.  Must be route 53 managed already.
-                     ResourceRecords: Seq[Token[String]],
+                     ResourceRecords: TokenSeq[String],
                      TTL:             Token[String],
                      Condition:       Option[ConditionRef] = None
                    ) = new `Custom::RemoteRoute53RecordSet`(name, ServiceToken, DestinationRole, RecordName, RecordType, Some(HostedZoneName), None, Some(ResourceRecords), Some(TTL), Condition = Condition)
@@ -157,7 +158,7 @@ object `Custom::RemoteRoute53RecordSet` {
                          RecordName:      Token[String], // The subdomain, with a . after it.
                          RecordType:      Route53RecordType,
                          HostedZoneID:    Token[String],
-                         ResourceRecords: Seq[Token[String]],
+                         ResourceRecords: TokenSeq[String],
                          TTL:             Token[String],
                          Condition:       Option[ConditionRef] = None
                        ) = new `Custom::RemoteRoute53RecordSet`(name, ServiceToken, DestinationRole, RecordName, RecordType, None, Some(HostedZoneID), Some(ResourceRecords), Some(TTL), Condition = Condition)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/SQS.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/SQS.scala
@@ -1,7 +1,8 @@
 package com.monsanto.arch.cloudformation.model.resource
 
-import com.monsanto.arch.cloudformation.model.{FunctionCallToken, `Fn::GetAtt`, Token, ConditionRef}
-import spray.json.{JsonFormat, DefaultJsonProtocol}
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
+import com.monsanto.arch.cloudformation.model.{ConditionRef, Token, `Fn::GetAtt`}
+import spray.json.{DefaultJsonProtocol, JsonFormat}
 
 /**
   * Created by Tyler Southwick on 11/18/15.
@@ -33,7 +34,7 @@ object `AWS::SQS::Queue` extends DefaultJsonProtocol {
 
 case class `AWS::SQS::QueuePolicy`(name: String,
                                    PolicyDocument: PolicyDocument,
-                                   Queues: Seq[Token[String]],
+                                   Queues: TokenSeq[String],
                                    override val Condition: Option[ConditionRef] = None
                                   ) extends Resource[`AWS::SQS::QueuePolicy`] {
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
@@ -1,8 +1,11 @@
 package com.monsanto.arch.cloudformation.model.simple
 
 import java.util.UUID
-import com.monsanto.arch.cloudformation.model.resource._
+
+import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.resource._
+
 import scala.language.implicitConversions
 
 object Builders extends
@@ -78,6 +81,7 @@ trait Route {
 }
 
 trait Instance {
+  import Token._
 
   implicit class RichInstance(ec2: `AWS::EC2::Instance`) {
 
@@ -289,7 +293,7 @@ trait Autoscaling {
       maxSize:     Int,
       desiredSize: Token[Int],
       tag:         String,
-      azs:         Seq[Token[String]],
+      azs:         TokenSeq[String],
       subnets:     Seq[Token[ResourceRef[`AWS::EC2::Subnet`]]],
       elbs:        Option[Seq[Token[ResourceRef[`AWS::ElasticLoadBalancing::LoadBalancer`]]]] = None
     )(implicit vpc: `AWS::EC2::VPC`) = {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/FnSplit_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/FnSplit_UT.scala
@@ -1,0 +1,77 @@
+package com.monsanto.arch.cloudformation.model
+
+import com.monsanto.arch.cloudformation.model.resource.LambdaVpcConfig
+import org.scalatest.{FunSpec, Matchers}
+import spray.json._
+
+class FnSplit_UT extends FunSpec with Matchers {
+
+  import Token._
+
+  describe("Fn::Split"){
+
+    it("Should serialize correctly with simple string arguments") {
+      val split: TokenSeq[String] = `Fn::Split`(",", "one,two")
+
+      val expected = JsObject(
+        "Fn::Split" → JsArray(
+          JsString(","),
+          JsString("one,two")
+        )
+      )
+
+      split.toJson should be(expected)
+    }
+
+    it("Should serialize correctly with complex argument types") {
+      val split: TokenSeq[String] = `Fn::Split`(",", `Fn::ImportValue`("importKey"))
+
+      val expected = JsObject(
+        "Fn::Split" → JsArray(
+          JsString(","),
+          JsObject(
+            "Fn::ImportValue" → JsString("importKey")
+          )
+        )
+      )
+
+      split.toJson should be(expected)
+    }
+
+    it("Should serialize correctly when used inside a resource") {
+      val resource = LambdaVpcConfig(Seq("sg-groupid"), `Fn::Split`(",", `Fn::ImportValue`("importKey")))
+
+      val expected = JsObject(
+        "SecurityGroupIds" → JsArray(JsString("sg-groupid")),
+        "SubnetIds" → JsObject(
+          "Fn::Split" → JsArray(
+            JsString(","),
+            JsObject(
+              "Fn::ImportValue" → JsString("importKey")
+            )
+          )
+        )
+      )
+
+      resource.toJson should be(expected)
+    }
+
+    it("Should implicitly convert inside a seq") {
+      val resource: TokenSeq[String] = Seq("test")
+
+      val expected = JsArray(JsString("test"))
+
+      resource.toJson should be(expected)
+    }
+
+    it("Should implicitly convert inside a seq with a function call") {
+      val resource: TokenSeq[String] = Seq(`Fn::Join`(",", Seq("test")))
+
+      val expected = JsArray(JsObject(
+        "Fn::Join" → JsArray(JsString(","), JsArray(JsString("test")))
+      ))
+
+      resource.toJson should be(expected)
+    }
+  }
+}


### PR DESCRIPTION
Resolves #140.

Because `Fn::Split` logically returns `Seq[Token[String]]`, I wanted to make sure it could be used anywhere `Seq[Token[String]]` is used today. That's why I added the `TokenSeq[R]` (which is a type alias for an `Either`): either the caller can use a hard-coded sequence of strings (or `Token[String]`s), or they can use `Fn::Split`. In the first case, the resulting JSON is a `JsArray`, and in the second, the resulting JSON is a `JsObject`. Either way, the `Either` should be fairly transparent to the caller because there are implicit functions that lift values into the `Left` or `Right` as appropriate.