### PR TITLE
Update IAM Policy Statements to support multiple resources

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -258,6 +258,9 @@ object Token extends DefaultJsonProtocol {
 
     override def read(json: JsValue): TokenSeq[R] = ???
   })
+
+  implicit def tokenStringToTokenSeqString(ts: Token[String]): TokenSeq[String] = Seq(ts)
+  implicit def tokenizableToTokenSeqString[T](ts: T)(implicit ev1: T ⇒ Token[String]): TokenSeq[String] = tokenStringToTokenSeqString(ts)
 }
 case class AnyToken[R : JsonFormat](value: R) extends Token[R]
 case class StringToken(value: String) extends Token[String]

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -145,12 +145,11 @@ object PolicyConditionValue extends DefaultJsonProtocol {
   implicit def tokenList2Value(s : Seq[Token[String]]): PolicyConditionValue = TokenListPolicyConditionValue(s)
 }
 
-
 case class PolicyStatement(
   Effect:    String,
   Principal: Option[PolicyPrincipal] = None,
   Action:    Seq[String],
-  Resource:  Option[Token[String]] = None,
+  Resource:  Option[TokenSeq[String]] = None,
   Condition: Option[Map[String, Map[String, PolicyConditionValue]]] = None,
   Sid:       Option[String] = None
 )

--- a/src/test/resources/cloudformation-template-vpc-example.json
+++ b/src/test/resources/cloudformation-template-vpc-example.json
@@ -283,7 +283,7 @@
                     "ec2:StartInstances",
                     "ec2:StopInstances"
                   ],
-                  "Resource":"*"
+                  "Resource":["*"]
                 }
               ]
             }
@@ -297,7 +297,7 @@
                   "Action":[
                     "s3:GetObject"
                   ],
-                  "Resource":{
+                  "Resource":[{
                     "Fn::Join":[
                       "",
                       [
@@ -306,7 +306,7 @@
                         "/*"
                       ]
                     ]
-                  }
+                  }]
                 }
               ]
             }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/IAMPolicy_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/IAMPolicy_UT.scala
@@ -1,13 +1,9 @@
 package com.monsanto.arch.cloudformation.model
 
+import com.monsanto.arch.cloudformation.model.resource.ValidPolicyCombo._
 import com.monsanto.arch.cloudformation.model.resource._
-import ValidPolicyCombo._
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.{FunSpec, Matchers}
 
-
-/**
- * Created by djdool on 7/9/15.
- */
 class IAMPolicy_UT extends FunSpec with Matchers with JsonWritingMatcher {
 
   describe("AWS::IAM::Policy") {
@@ -112,6 +108,21 @@ class IAMPolicy_UT extends FunSpec with Matchers with JsonWritingMatcher {
           |    "Action": ["*"]
           |  }],
           |  "Version": "2012-10-17"
+          |}
+        """.stripMargin
+    }
+
+    it("should generate policy statement with resources") {
+      PolicyDocument(
+        Statement = Seq(PolicyStatement(Effect = "Allow",Action = Seq("*"), Resource = Some(Seq("arn:1", "arn:2"))))
+      ) shouldMatch
+        """
+          |{
+          |  "Statement": [{
+          |    "Effect": "Allow",
+          |    "Action": ["*"],
+          |    "Resource": ["arn:1", "arn:2"]
+          |  }]
           |}
         """.stripMargin
     }


### PR DESCRIPTION
This should make writing policy statements that affect multiple resources a lot cleaner. Right now, AFAICT you have to break them out into multiple statements, which is hard to read in the generated template and, eventually, the generated policy. [Multiple resources are supported by IAM.](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Resource)

This should be backwards-compatible with the exception that one has to 
```scala
import com.monsanto.arch.cloudformation.model.resource.PolicyStatement._
```
to get the implicits. I'm open to moving them to another location that is more likely to already be imported if someone has an idea of where that might be.

The generated JSON will now always contain an array for the `Resource` field, but that should have no impact as far as CloudFormation/IAM are concerned, and matches the behavior of the [Python AWACS library](https://github.com/cloudtools/awacs/blob/master/awacs/aws.py#L143).