### PR TITLE
Change `Path` type in IAM resources to be `Token[String]`

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -13,7 +13,7 @@ import scala.language.implicitConversions
 
 case class `AWS::IAM::InstanceProfile`(
   name:  String,
-  Path:  String,
+  Path:  Token[String],
   Roles: Seq[ResourceRef[`AWS::IAM::Role`]],
   override val Condition: Option[ConditionRef] = None
   ) extends Resource[`AWS::IAM::InstanceProfile`] with HasArn {
@@ -71,7 +71,7 @@ case class `AWS::IAM::ManagedPolicy`(
   name:           String,
   PolicyDocument: PolicyDocument,
   Description:    Option[String] = None,
-  Path:           Option[String] = None,
+  Path:           Option[Token[String]] = None,
   Groups:         Option[Seq[ResourceRef[`AWS::IAM::Group`]]] = None,
   Roles:          Option[Seq[ResourceRef[`AWS::IAM::Role`]]] = None,
   Users:          Option[Seq[ResourceRef[`AWS::IAM::User`]]] = None,


### PR DESCRIPTION
Fixes #148 

This may warrant a minor version bump. The implicit conversion from `String` to `Token[String]` should take care of `InstanceProfile`. Since there's also an implicit conversion from `T` to `Option[T]`, if people did not explicitly specify the `Path` in `ManagedPolicy` as `Some("blah")`, compilation will fail since only one implicit conversion will be applied.