### PR TITLE
Add ProviderArns to `AWS::ApiGateway::Authorizer`

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway.scala
@@ -42,7 +42,7 @@ case class `AWS::ApiGateway::Authorizer`(
                                           name: String,
                                           AuthorizerCredentials: Option[Token[String]] = None,
                                           AuthorizerResultTtlInSeconds: Option[Token[Int]] = None,
-                                          AuthorizerUri: Token[String],
+                                          AuthorizerUri: Option[Token[String]] = None,
                                           IdentitySource: Option[Token[String]] = None,
                                           IdentityValidationExpression: Option[Token[String]] = None,
                                           Name: Option[Token[String]] = None,

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway.scala
@@ -46,6 +46,7 @@ case class `AWS::ApiGateway::Authorizer`(
                                           IdentitySource: Option[Token[String]] = None,
                                           IdentityValidationExpression: Option[Token[String]] = None,
                                           Name: Option[Token[String]] = None,
+                                          ProviderArns: Option[Seq[String]] = None,
                                           RestApiId: Option[Token[String]] = None,
                                           Type: Option[String] = None,
                                           override val Condition: Option[ConditionRef] = None
@@ -55,7 +56,7 @@ case class `AWS::ApiGateway::Authorizer`(
   override def when(newCondition: Option[ConditionRef]) = copy(Condition = newCondition)
 }
 object `AWS::ApiGateway::Authorizer` {
-  implicit val format: JsonFormat[`AWS::ApiGateway::Authorizer`] = jsonFormat10(`AWS::ApiGateway::Authorizer`.apply)
+  implicit val format: JsonFormat[`AWS::ApiGateway::Authorizer`] = jsonFormat11(`AWS::ApiGateway::Authorizer`.apply)
 }
 
 


### PR DESCRIPTION
This adds the missing ProviderArns to `AWS::ApiGateway::Authorizer` as
described here http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-authorizer.html#cfn-apigateway-authorizer-providerarns