### PR TITLE
Add support for ContainerDefinition MountPoints

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ECS.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ECS.scala
@@ -178,6 +178,7 @@ object ContainerDefinition extends DefaultJsonProtocol {
         "LogConfiguration" → cd.LogConfiguration.toJson,
         "Memory" → cd.Memory.toJson,
         "MemoryReservation" → cd.MemoryReservation.toJson,
+        "MountPoints" → cd.MountPoints.toJson,
         "Name" → cd.Name.toJson,
         "PortMappings" → cd.PortMappings.toJson,
         "Privileged" → cd.Privileged.toJson,

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ECS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ECS_UT.scala
@@ -84,6 +84,50 @@ class ECS_UT extends FunSpec with Matchers {
 
       resource.arn should be(ResourceRef(resource))
     }
+
+    it("should not allow MountPoint without matching VolumeDefinition") {
+
+      val ex = intercept[IllegalArgumentException] {
+        `AWS::ECS::TaskDefinition`("test",
+          ContainerDefinitions = Seq(
+            ContainerDefinition(
+              Name = "hello",
+              Image = "",
+              MemoryReservation = Option(64),
+              MountPoints = Seq(
+                MountPoint(
+                  ContainerPath = "aba",
+                  SourceVolume = "aba"
+                )
+              )
+            )
+          )
+        )
+      }
+
+      ex.getMessage should include ("MountPoint(StringToken(aba),aba,None) specifies a source volume, aba, that does not exist in task definition test")
+    }
+
+    it("should allow MountPoint with matching VolumeDefinition") {
+      `AWS::ECS::TaskDefinition`("test",
+        Volumes = Seq(
+          VolumeDefinition("aba", Host = Some(Host(Some("/somewhere-on-the-host"))))
+        ),
+        ContainerDefinitions = Seq(
+          ContainerDefinition(
+            Name = "hello",
+            Image = "",
+            MemoryReservation = Option(64),
+            MountPoints = Seq(
+              MountPoint(
+                ContainerPath = "/somewhere-on-the-container",
+                SourceVolume = "aba"
+              )
+            )
+          )
+        )
+      )
+    }
   }
 
   describe("AWS::ECS::Service") {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ECS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ECS_UT.scala
@@ -109,7 +109,7 @@ class ECS_UT extends FunSpec with Matchers {
     }
 
     it("should allow MountPoint with matching VolumeDefinition") {
-      `AWS::ECS::TaskDefinition`("test",
+      val resource = `AWS::ECS::TaskDefinition`("test",
         Volumes = Seq(
           VolumeDefinition("aba", Host = Some(Host(Some("/somewhere-on-the-host"))))
         ),
@@ -127,6 +127,14 @@ class ECS_UT extends FunSpec with Matchers {
           )
         )
       )
+
+      val js = resource.toJson
+
+      val jsContainerDef = js.asJsObject.fields("ContainerDefinitions").asInstanceOf[JsArray].elements(0).asJsObject
+
+      jsContainerDef.fields should contain key "MountPoints"
+      js.prettyPrint should include (""""ContainerPath": "/somewhere-on-the-container"""")
+      js.prettyPrint should include (""""SourcePath": "/somewhere-on-the-host"""")
     }
   }
 


### PR DESCRIPTION
The TaskDefinition also validates that the any ContainerDefinitions' MountPoints' SourceVolume names matche one of the Volumes in the TaskDefinition.

Fixes #163