### PR TITLE
Make AllocatedStorage optional for non-NewRds instances

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model.scala
@@ -138,7 +138,7 @@ package object model {
   implicit def parameter2TokenString(parameter : StringParameter) : Token[String] = ParameterRef(parameter)
 
   implicit def eitherAfuncA2OptionEitherAfuncA[A](v: Either[A, AmazonFunctionCall[A]]): Option[Either[A, Token[A]]] =
-    Some(v.map(Token.fromFunction[A]))
+    Some(v.right.map(Token.fromFunction[A]))
 
   /**
     * Provides a string interpolator to assist in the concatenation of

--- a/src/main/scala/com/monsanto/arch/cloudformation/model.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model.scala
@@ -138,7 +138,7 @@ package object model {
   implicit def parameter2TokenString(parameter : StringParameter) : Token[String] = ParameterRef(parameter)
 
   implicit def eitherAfuncA2OptionEitherAfuncA[A](v: Either[A, AmazonFunctionCall[A]]): Option[Either[A, Token[A]]] =
-    Some(v.map(Token.fromFunction))
+    Some(v.map(Token.fromFunction[A]))
 
   /**
     * Provides a string interpolator to assist in the concatenation of

--- a/src/main/scala/com/monsanto/arch/cloudformation/model.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model.scala
@@ -137,6 +137,9 @@ package object model {
 
   implicit def parameter2TokenString(parameter : StringParameter) : Token[String] = ParameterRef(parameter)
 
+  implicit def eitherAfuncA2OptionEitherAfuncA[A](v: Either[A, AmazonFunctionCall[A]]): Option[Either[A, Token[A]]] =
+    Some(v.map(Token.fromFunction))
+
   /**
     * Provides a string interpolator to assist in the concatenation of
     *


### PR DESCRIPTION
It turned out that this wasn't as difficult as I imagined it would be. It does verify that allocated storage is specified for a NewRds instances where it would make no sense for that property to be omitted.

Fixes MonsantoCo/cloudformation-template-generator#172