### PR TITLE
Cache the ivy cache, compiled compiler interface, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 language: scala
+
 jdk:
   - oraclejdk8
+
+before_cache:
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+
+cache:
+  directories:
+  - $HOME/.ivy2/cache/
+  - $HOME/.sbt/boot/
+
 script: "sbt +clean +coverage +test"
+
 after_success: "sbt +coveralls"


### PR DESCRIPTION
This is just something I noticed while waiting for a PR check to complete. We've noticed that caching these two directories definitely helps speed up build time.