### PR TITLE
Align managed policy arns parameter types

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -167,7 +167,7 @@ object PolicyStatement extends DefaultJsonProtocol {
 
 case class `AWS::IAM::Group`(
   name:              String,
-  ManagedPolicyArns: Option[Seq[ResourceRef[`AWS::IAM::ManagedPolicy`]]] = None,
+  ManagedPolicyArns: Option[Seq[ManagedPolicyARN]] = None,
   Path:              Option[Token[String]] = None,
   Policies:          Option[Seq[Policy]] = None,
   override val Condition: Option[ConditionRef] = None

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -69,12 +69,13 @@ object AccessKeyStatus extends DefaultJsonProtocol{
 
 case class `AWS::IAM::ManagedPolicy`(
   name:           String,
-  PolicyDocument: PolicyDocument,
-  Description:    Option[String] = None,
-  Path:           Option[Token[String]] = None,
-  Groups:         Option[Seq[ResourceRef[`AWS::IAM::Group`]]] = None,
-  Roles:          Option[Seq[ResourceRef[`AWS::IAM::Role`]]] = None,
-  Users:          Option[Seq[ResourceRef[`AWS::IAM::User`]]] = None,
+  PolicyDocument:     PolicyDocument,
+  ManagedPolicyName:  Option[Token[String]] = None,
+  Description:        Option[String] = None,
+  Path:               Option[Token[String]] = None,
+  Groups:             Option[Seq[ResourceRef[`AWS::IAM::Group`]]] = None,
+  Roles:              Option[Seq[ResourceRef[`AWS::IAM::Role`]]] = None,
+  Users:              Option[Seq[ResourceRef[`AWS::IAM::User`]]] = None,
   override val Condition: Option[ConditionRef] = None
   ) extends Resource[`AWS::IAM::ManagedPolicy`] {
 
@@ -82,7 +83,7 @@ case class `AWS::IAM::ManagedPolicy`(
 }
 
 object `AWS::IAM::ManagedPolicy` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::IAM::ManagedPolicy`] = jsonFormat8(`AWS::IAM::ManagedPolicy`.apply)
+  implicit val format: JsonFormat[`AWS::IAM::ManagedPolicy`] = jsonFormat9(`AWS::IAM::ManagedPolicy`.apply)
 }
 
 sealed trait ManagedPolicy
@@ -167,6 +168,7 @@ object PolicyStatement extends DefaultJsonProtocol {
 
 case class `AWS::IAM::Group`(
   name:              String,
+  GroupName:         Option[Token[String]] = None,
   ManagedPolicyArns: Option[Seq[ManagedPolicyARN]] = None,
   Path:              Option[Token[String]] = None,
   Policies:          Option[Seq[Policy]] = None,
@@ -175,7 +177,7 @@ case class `AWS::IAM::Group`(
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 object `AWS::IAM::Group` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::IAM::Group`] = jsonFormat5(`AWS::IAM::Group`.apply)
+  implicit val format: JsonFormat[`AWS::IAM::Group`] = jsonFormat6(`AWS::IAM::Group`.apply)
 }
 
 @implicitNotFound("you can only specify one of Groups, Roles, or Users")


### PR DESCRIPTION
* Added name field for managed policies and IAM groups.
* Changed AWS::IAM::Group managed policy parameter type to match  AWS::IAM::Role. The previous type was  ```Option[Seq[ResourceRef[`AWS::IAM::ManagedPolicy`]]]```, this causes issues when not creating a resource and using predefined AWS managed policies.