### PR TITLE
Make LogDestination.DestinationPolicy take a JsonString

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/JsonString.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/JsonString.scala
@@ -1,0 +1,12 @@
+package com.monsanto.arch.cloudformation.model
+
+import spray.json._
+
+case class JsonString[A](value: A)
+
+object JsonString extends DefaultJsonProtocol {
+  implicit def format[A](implicit F: JsonFormat[A]): JsonFormat[JsonString[A]] = new JsonFormat[JsonString[A]] {
+    override def write(obj: JsonString[A]) = JsString(obj.value.toJson.compactPrint)
+    override def read(json: JsValue): JsonString[A] = JsonString(F.read(json))
+  }
+}

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Logs.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Logs.scala
@@ -21,18 +21,16 @@ import spray.json._
   *                  CloudFormation creates the associated resources.
   * @param DependsOn Declare dependencies for resources that must be created or deleted in a specific order.
   */
-case class `AWS::Logs::Destination` private (
+case class `AWS::Logs::Destination`(
   name:                   String,
   DestinationName:        Token[String],
-  DestinationPolicy:      ResourceRef[`AWS::IAM::Policy`],
+  DestinationPolicy:      JsonString[PolicyDocument],
   RoleArn:                Token[String],
   TargetArn:              Token[String],
   override val Condition: Option[ConditionRef] = None,
   override val DependsOn: Option[Seq[String]]  = None
 ) extends Resource[`AWS::Logs::Destination`] with HasArn {
-
   def when(newCondition: Option[ConditionRef] = Condition): `AWS::Logs::Destination` = copy(Condition = newCondition)
-
   override def arn: Token[String] = ResourceRef(this)
 }
 
@@ -54,7 +52,7 @@ object `AWS::Logs::Destination` extends DefaultJsonProtocol {
   *                  CloudFormation creates the associated resources.
   * @param DependsOn Declare dependencies for resources that must be created or deleted in a specific order.
   */
-case class `AWS::Logs::LogGroup` private (
+case class `AWS::Logs::LogGroup`(
   name:                   String,
   LogGroupName:           Option[Token[String]],
   RetentionInDays:        Token[Int],
@@ -83,7 +81,7 @@ object `AWS::Logs::LogGroup` extends DefaultJsonProtocol {
   *                  CloudFormation creates the associated resources.
   * @param DependsOn Declare dependencies for resources that must be created or deleted in a specific order.
   */
-case class `AWS::Logs::LogStream` private (
+case class `AWS::Logs::LogStream`(
   name:                   String,
   LogGroupName:           ResourceRef[`AWS::Logs::LogGroup`],
   LogStreamName:          Option[Token[String]],
@@ -116,7 +114,7 @@ object `AWS::Logs::LogStream` extends DefaultJsonProtocol {
   *                  CloudFormation creates the associated resources.
   * @param DependsOn Declare dependencies for resources that must be created or deleted in a specific order.
   */
-case class `AWS::Logs::MetricFilter` private (
+case class `AWS::Logs::MetricFilter`(
   name:                   String,
   FilterPattern:          Token[String],
   LogGroupName:           ResourceRef[`AWS::Logs::LogGroup`],
@@ -177,7 +175,7 @@ object MetricTransformation extends DefaultJsonProtocol {
   *                  CloudFormation creates the associated resources.
   * @param DependsOn Declare dependencies for resources that must be created or deleted in a specific order.
   */
-case class `AWS::Logs::SubscriptionFilter` private (
+case class `AWS::Logs::SubscriptionFilter`(
   name:                   String,
   DestinationArn:         Token[String],
   FilterPattern:          Token[String],

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Logs_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Logs_UT.scala
@@ -1,0 +1,36 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model._
+import org.scalatest.{ FunSpec, Matchers }
+import spray.json._
+
+class Logs_UT extends FunSpec with Matchers {
+  describe("Destination") {
+    val dest = `AWS::Logs::Destination`(
+      name = "foo",
+      DestinationName = "bar",
+      DestinationPolicy = JsonString(
+        PolicyDocument(
+          Statement = Seq(
+            PolicyStatement(
+              Effect = "Allow",
+              Action = Seq("fire")
+            )
+          )
+        )
+      ),
+      RoleArn = "role",
+      TargetArn = "target"
+    )
+
+    it("should write a valid Log Destination") {
+      dest.toJson shouldEqual JsObject(
+        "name" -> JsString("foo"),
+        "DestinationName" -> JsString("bar"),
+        "DestinationPolicy" -> JsString("""{"Statement":[{"Effect":"Allow","Action":["fire"]}]}"""),
+        "RoleArn" -> JsString("role"),
+        "TargetArn" -> JsString("target")
+      )
+    }
+  }
+}


### PR DESCRIPTION
It clearly states in the docs that this is a String argument,
and we should not force people to make an IAM Policy and attach
it to some random group or user just so we can use it in
this field.