### PR TITLE
Make Output.Description optional

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Output.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Output.scala
@@ -10,18 +10,15 @@ import scala.collection.immutable.ListMap
   * Created by Ryan Richt on 2/15/15
   */
 
-case class Output[R](name: String, Description: String, Value: Token[R], Export: Option[Token[String]] = None)(implicit format: JsonFormat[Token[R]]) {
+case class Output[R](name: String, Description: Option[String] = None, Value: Token[R], Export: Option[Token[String]] = None)(implicit format: JsonFormat[Token[R]]) {
   def valueAsJson = Token.format[Token[R]].write(Value)
 }
 
 object Output extends DefaultJsonProtocol {
-
   implicit def format[A] : JsonWriter[Output[A]] = new JsonWriter[Output[A]]  {
     override def write(obj: Output[A]) = {
-      JsObject(Map(
-        "Description" -> JsString(obj.Description),
-        "Value" -> obj.valueAsJson)
-        ++ exportAsJsonTuple(obj))
+      val m1 = obj.Description map (d => Map("Description" -> JsString(d))) getOrElse Map.empty[String, JsValue]
+      JsObject(m1 ++ Map("Value" -> obj.valueAsJson) ++ exportAsJsonTuple(obj))
     }
 
     def exportAsJsonTuple(obj: Output[A]): Option[(String, JsValue)] = obj.Export match {


### PR DESCRIPTION
This is a breaking change.  Adding an apply function like so

  @deprecated("Please use default constuctor", "3.7.2")
  def apply[R](name: String, Description: String, Value: Token[R], Export: Option[Token[String]] = None)(implicit format: JsonFormat[Token[R]]): Output[R] =
    apply(name, Some(Description), Value, Export)

is not possible because there are multiple values with default parameters.