### PR TITLE
Make Template match documentation

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
@@ -7,7 +7,6 @@ import DefaultJsonProtocol._
 
 import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
 
 /**
  * Template is the container for all the elements of your
@@ -16,20 +15,13 @@ import scala.reflect.ClassTag
  * {{{
  *   // create the template
  *   val simpleTemplate = Template(
- *     AWSTemplateFormatVersion = "2010-09-09",
- *     Description = "Simple S3 Bucket Template",
- *     Resources = Some(
- *       Seq(
- *         `AWS::S3::Bucket`(
- *           name = "S3Bucket",
- *           BucketName = Some("UniqueBucketForSimpleTemplate")
- *         )
+ *     Description = Some("Simple S3 Bucket Template"),
+ *     Resources = Seq(
+ *       `AWS::S3::Bucket`(
+ *         name = "S3Bucket",
+ *         BucketName = Some("UniqueBucketForSimpleTemplate")
  *       )
- *     ),
- *     Parameters = None,
- *     Conditions = None,
- *     Mappings = None,
- *     Outputs = None
+ *     )
  *   )
  * }}}
  * @param Description See [[http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-description-structure.html description]]
@@ -42,16 +34,15 @@ import scala.reflect.ClassTag
  *
  */
 case class Template(
-                    Description: String,
-                    Parameters:  Option[Seq[Parameter]],
-                    Conditions:  Option[Seq[Condition]],
-                    Mappings:    Option[Seq[Mapping[_]]],
-                    Resources:   Option[Seq[Resource[_]]],
+                    Description: Option[String] = None,
+                    Parameters:  Option[Seq[Parameter]] = None,
+                    Conditions:  Option[Seq[Condition]] = None,
+                    Mappings:    Option[Seq[Mapping[_]]] = None,
+                    Resources:   Seq[Resource[_]],
                     Routables:   Option[Seq[SecurityGroupRoutable[_ <: Resource[_]]]] = None,
-                    Outputs:     Option[Seq[Output[_]]],
-                    AWSTemplateFormatVersion: String = "2010-09-09"
+                    Outputs:     Option[Seq[Output[_]]] = None,
+                    AWSTemplateFormatVersion: Option[String] = None
                    ){
-
   def lookupResource[R <: Resource[R]](name: String): R = {
     if(Resources.isEmpty) throw new RuntimeException("You cannot lookup in a None map")
     val candidates = Resources.get.filter{r => r.name == name}
@@ -77,11 +68,11 @@ case class Template(
     else Some(s1.getOrElse(Seq.empty[T]) ++ s2.getOrElse(Seq.empty[T]))
 
   def ++(t: Template) = Template(
-    Description + t.Description,
+    Description flatMap (_ + t.Description.getOrElse("")),
     mergeOptionSeq(Parameters, t.Parameters ),
     mergeOptionSeq(Conditions, t.Conditions ),
     mergeOptionSeq(Mappings,   t.Mappings   ),
-    mergeOptionSeq(Resources,  t.Resources  ),
+    Resources ++ t.Resources,
     mergeOptionSeq(Routables,  t.Routables  ),
     mergeOptionSeq(Outputs,    t.Outputs    ),
     this.AWSTemplateFormatVersion
@@ -89,7 +80,7 @@ case class Template(
 }
 object Template extends DefaultJsonProtocol {
 
-  val EMPTY = Template("", None, None, None, None, None, None)
+  val EMPTY = Template(None, None, None, None, Seq(), None, None)
 
   def collapse[R <: Resource[R]](rs: Seq[R]): Template = {
     val dupes = rs.groupBy(_.name).collect{case(y,xs) if xs.size>1 => y}
@@ -108,36 +99,36 @@ object Template extends DefaultJsonProtocol {
   implicit val format: JsonWriter[Template] = new JsonWriter[Template]{
     def write(p: Template) = {
       val fields = new collection.mutable.ListBuffer[(String, JsValue)]
-      fields ++= productElement2Field[String]("AWSTemplateFormatVersion", p, 7)
-      fields ++= productElement2Field[String]("Description", p, 0)
+      if(p.AWSTemplateFormatVersion.nonEmpty) fields ++= productElement2Field[Option[String]]("AWSTemplateFormatVersion", p, 7)(optionWriter)
+      if(p.Description.nonEmpty) fields ++= productElement2Field[Option[String]]("Description", p, 0)(optionWriter)
       if(p.Parameters.nonEmpty) fields ++= productElement2Field[Option[Seq[Parameter]]]("Parameters", p, 1)
       if(p.Conditions.nonEmpty) fields ++= productElement2Field[Option[Seq[Condition]]]("Conditions", p, 2)
       if(p.Mappings.nonEmpty) fields ++= productElement2Field[Option[Seq[Mapping[_]]]]("Mappings", p, 3)
-      if(p.Resources.nonEmpty) fields ++= productElement2Field[Option[Seq[Resource[_]]]]("Resources", p, 4)
+      fields ++= productElement2Field[Seq[Resource[_]]]("Resources", p, 4)
       if(p.Outputs.nonEmpty) fields ++= productElement2Field[Option[Seq[Output[_]]]]("Outputs", p, 6)
       JsObject(ListMap(fields: _*))
     }
   }
 
-  implicit def fromParameter(p: Parameter): Template = Template("", Seq(p), None, None, None, None, None)
-  implicit def fromParameters(ps: Seq[Parameter]): Template = Template("", ps, None, None, None, None, None)
+  implicit def fromParameter(p: Parameter): Template = EMPTY.copy(Parameters = Seq(p))
+  implicit def fromParameters(ps: Seq[Parameter]): Template = EMPTY.copy(Parameters = ps)
 
-  implicit def fromCondition(c: Condition): Template = Template("",None, Seq(c), None, None, None, None)
-  implicit def fromConditions(cs: Seq[Condition]): Template = Template("",None, cs, None, None, None, None)
+  implicit def fromCondition(c: Condition): Template = EMPTY.copy(Conditions = Seq(c))
+  implicit def fromConditions(cs: Seq[Condition]): Template = EMPTY.copy(Conditions = cs)
 
-  implicit def fromMapping(m: Mapping[_]): Template = Template("", None, None, Seq(m), None, None, None)
-  implicit def fromMappings(ms: Seq[Mapping[_]]): Template = Template("", None, None, ms, None, None, None)
+  implicit def fromMapping(m: Mapping[_]): Template = EMPTY.copy(Mappings = Seq(m))
+  implicit def fromMappings(ms: Seq[Mapping[_]]): Template = EMPTY.copy(Mappings = ms)
 
-  implicit def fromResource[R <: Resource[R]](r: R): Template = Template("", None, None, None, Some(Seq(r)), None, None)
-  implicit def fromResources[R <: Resource[R]](rs: Seq[R]): Template = Template("", None, None, None, Some(rs), None, None)
+  implicit def fromResource[R <: Resource[R]](r: R): Template = EMPTY.copy(Resources = Seq(r))
+  implicit def fromResources[R <: Resource[R]](rs: Seq[R]): Template = EMPTY.copy(Resources = rs)
 
   implicit def fromSecurityGroupRoutable[R <: Resource[R]](sgr: SecurityGroupRoutable[R]): Template =
-    Template("", None, None, None, Some(sgr.resources), Some(Seq(sgr)), None)
+    Template(None, None, None, None, sgr.resources, Some(Seq(sgr)), None)
   implicit def fromSecurityGroupRoutables[R <: Resource[R]](sgrs: Seq[SecurityGroupRoutable[R]]): Template =
-    Template("", None, None, None, Some(sgrs.flatMap(sgr => sgr.resources)), Some(sgrs), None)
+    Template(None, None, None, None, sgrs.flatMap(_.resources), Some(sgrs), None)
 
-  implicit def fromOutput(o: Output[_]): Template = Template("", None, None, None, None, None, Some(Seq(o)))
-  implicit def fromOutputs(os: Seq[Output[_]]): Template = Template("", None, None, None, None, None, Some(os))
+  implicit def fromOutput(o: Output[_]): Template = EMPTY.copy(Outputs = Some(Seq(o)))
+  implicit def fromOutputs(os: Seq[Output[_]]): Template = EMPTY.copy(Outputs = Some(os))
 
   implicit def toHasTemplate(template : Template) : HasTemplate = {
     val thatTemplate = template

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/TemplateBase.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/TemplateBase.scala
@@ -51,7 +51,7 @@ trait TemplateBase extends HasTemplate {
       Parameters = extract[Parameter],
       Conditions = extract[Condition],
       Mappings = extract[Mapping[_]],
-      Resources = extract[Resource[_]],
+      Resources = extract[Resource[_]] getOrElse Seq(),
       Routables = extract[SecurityGroupRoutable[_ <: Resource[_]]],
       Outputs = extract[Output[_]]
     )

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Events.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Events.scala
@@ -13,16 +13,16 @@ case class `AWS::Events::Rule`(name: String,
                                override val DependsOn: Option[Seq[String]] = None,
                                override val Condition: Option[ConditionRef] = None
                               ) extends Resource[`AWS::Events::Rule`] {
-  
+
   require(EventPattern.isDefined || ScheduleExpression.isDefined, "AWS::Events::Rule must have either EventPattern and/or ScheduledExpression specified")
-  
+
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 
 object `AWS::Events::Rule` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::Events::Rule`] = jsonFormat9(`AWS::Events::Rule`.apply)
 
-  @deprecated("This method is broken.  Please update.")
+  @deprecated("This method is broken.  Please update.", "3.7.1")
   def apply(name: String,
             ScheduleExpression: Token[String],
             Targets: Seq[Option[RuleTarget]],
@@ -34,7 +34,7 @@ object `AWS::Events::Rule` extends DefaultJsonProtocol {
     Condition = Condition
   )
 
-  @deprecated("This method is broken.  Please update.")
+  @deprecated("This method is broken.  Please update.", "3.7.1")
   def apply(name: String,
             ScheduleExpression: Token[String],
             Targets: Seq[Option[RuleTarget]]): `AWS::Events::Rule` =

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/CloudFormation_AT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/CloudFormation_AT.scala
@@ -947,8 +947,8 @@ object StaxTemplate {
   )
 
   val itsaDockerStack = Template(
-    AWSTemplateFormatVersion = "2010-09-09",
-    Description = "Autoscaling group of Docker engines in dual AZ VPC with two NAT nodes in an active/active configuration. After successfully launching this CloudFormation stack, you will have 4 subnets in 2 AZs (a pair of public/private subnets in each AZ), a jump box, two NAT instances routing outbound traffic for their respective private subnets.  The NAT instances will automatically monitor each other and fix outbound routing problems if the other instance is unavailable.  The Docker engine autoscaling group will deploy to the private subnets.",
+    AWSTemplateFormatVersion = Some("2010-09-09"),
+    Description = Some("Autoscaling group of Docker engines in dual AZ VPC with two NAT nodes in an active/active configuration. After successfully launching this CloudFormation stack, you will have 4 subnets in 2 AZs (a pair of public/private subnets in each AZ), a jump box, two NAT instances routing outbound traffic for their respective private subnets.  The NAT instances will automatically monitor each other and fix outbound routing problems if the other instance is unavailable.  The Docker engine autoscaling group will deploy to the private subnets."),
     Parameters = Some(
       Seq(
 
@@ -998,7 +998,7 @@ object StaxTemplate {
       )
     ),
 
-    Resources = Some(
+    Resources =
       Seq(
         natRoleResource,
       natRoleProfileResource,
@@ -1113,7 +1113,6 @@ object StaxTemplate {
 
       coreOSServerAutoScaleResource.withPolicy("CoreOSServerAutoScaleUpPolicy", 1, ParameterRef(autoScaleCoolDownParam)),
       coreOSServerAutoScaleResource.withPolicy("CoreOSServerAutoScaleDownPolicy", -1, ParameterRef(autoScaleCoolDownParam))
-    )
     ),
 
     Outputs = Some(

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/TemplateBaseSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/TemplateBaseSpec.scala
@@ -1,5 +1,5 @@
 package com.monsanto.arch.cloudformation.model
-
+import scala.language.reflectiveCalls
 import com.monsanto.arch.cloudformation.model.resource.`AWS::SQS::Queue`
 import org.scalatest.{FunSpec, Matchers}
 
@@ -21,7 +21,7 @@ class TemplateBaseSpec extends FunSpec with Matchers {
 
     MyTemplate.template.Outputs.toSeq.flatten should contain(MyTemplate.out1)
     MyTemplate.template.Parameters.toSeq.flatten should contain(MyTemplate.param1)
-    MyTemplate.template.Resources.toSeq.flatten should contain(MyTemplate.resource1)
+    MyTemplate.template.Resources should contain(MyTemplate.resource1)
   }
 
   it("should find instances of HasTemplate") {
@@ -50,8 +50,8 @@ class TemplateBaseSpec extends FunSpec with Matchers {
       }
     }
 
-    MyTemplate.template.Resources.toSeq.flatten should contain(MyTemplate.anotherTemplate.resource1)
-    MyTemplate.template.Resources.toSeq.flatten should contain(MyTemplate.anotherTemplate2.resource)
+    MyTemplate.template.Resources should contain(MyTemplate.anotherTemplate.resource1)
+    MyTemplate.template.Resources should contain(MyTemplate.anotherTemplate2.resource)
   }
 
   it("should find instances of Template") {
@@ -69,7 +69,7 @@ class TemplateBaseSpec extends FunSpec with Matchers {
 
     }
 
-    MyTemplate.template.Resources.toSeq.flatten should contain(queue)
+    MyTemplate.template.Resources should contain(queue)
   }
 
 }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/TemplateDoc_AT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/TemplateDoc_AT.scala
@@ -100,12 +100,11 @@ class TemplateDoc_AT extends FunSpec with Matchers {
         }
         val simpleTemplate = simpleResourceAndOutputs ++
           Template(
-            AWSTemplateFormatVersion = "2010-09-09",
-            Description = "Simple template",
+            Description = Some("Simple template"),
             Parameters = Some(simpleParameters),
             Conditions = Some(simpleConditions),
             Mappings = Some(simpleMappings),
-            Resources = None,
+            Resources = Seq(), // Illegal
             Outputs = None
           )
         writeStaxModule("vpc-simple.json", simpleTemplate)

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/Template_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/Template_UT.scala
@@ -66,13 +66,13 @@ class Template_UT extends FlatSpec with Matchers with VPC with Subnet with Avail
 
   it should "be able to add a resource" in {
     val template = Template.EMPTY ++ resource1
-    template should equal(Template.EMPTY.copy(Resources = Some(Seq(resource1))))
+    template should equal(Template.fromResource(resource1))
   }
 
   it should "be able to add resources" in {
     val resources = Seq(resource1, resource2)
     val template = Template.EMPTY ++ resources
-    template should equal(Template.EMPTY.copy(Resources = Some(resources)))
+    template should equal(Template.fromResources(resources))
   }
 
   val cidr = CidrBlock(10,1,1,1,32)

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ApiGateway_UT.scala
@@ -53,8 +53,6 @@ class ApiGateway_UT extends FunSpec with Matchers {
       val expectedJson =
         """
           |{
-          |  "AWSTemplateFormatVersion": "2010-09-09",
-          |  "Description": "",
           |  "Resources": {
           |    "UsagePlan": {
           |      "Properties": {
@@ -78,8 +76,6 @@ class ApiGateway_UT extends FunSpec with Matchers {
       val expectedJson =
         """
           |{
-          |  "AWSTemplateFormatVersion": "2010-09-09",
-          |  "Description": "",
           |  "Resources": {
           |    "UsagePlanKey": {
           |      "Properties": {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CodeCommit_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CodeCommit_UT.scala
@@ -28,8 +28,6 @@ class CodeCommit_UT extends FunSpec with Matchers {
       val expectedJson =
         """
           |{
-          |  "AWSTemplateFormatVersion": "2010-09-09",
-          |  "Description": "",
           |  "Resources": {
           |    "RepoFoo": {
           |      "Properties": {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Route53_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Route53_UT.scala
@@ -22,8 +22,6 @@ class Route53_UT extends FunSpec with Matchers {
       val expectedJson =
         """
           |{
-          |  "AWSTemplateFormatVersion": "2010-09-09",
-          |  "Description": "",
           |  "Resources": {
           |    "TestRecord": {
           |      "Properties": {


### PR DESCRIPTION
This is a breaking change.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html

I think it's worth the pain.  It's bad to have one of the most primitive
data structures not match the spec.