### PR TITLE
Make LogGroupName in MetricFilter and SubscriptionFilter accept Token[String]

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Logs.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Logs.scala
@@ -117,7 +117,7 @@ object `AWS::Logs::LogStream` extends DefaultJsonProtocol {
 case class `AWS::Logs::MetricFilter` private (
   name:                   String,
   FilterPattern:          Token[String],
-  LogGroupName:           ResourceRef[`AWS::Logs::LogGroup`],
+  LogGroupName:           Token[String],
   MetricTransformations:  Seq[MetricTransformation],
   override val Condition: Option[ConditionRef] = None,
   override val DependsOn: Option[Seq[String]]  = None
@@ -179,7 +179,7 @@ case class `AWS::Logs::SubscriptionFilter` private (
   name:                   String,
   DestinationArn:         Token[String],
   FilterPattern:          Token[String],
-  LogGroupName:           ResourceRef[`AWS::Logs::LogGroup`],
+  LogGroupName:           Token[String],
   RoleArn:                Option[Token[String]] = None,
   override val Condition: Option[ConditionRef] = None,
   override val DependsOn: Option[Seq[String]]  = None


### PR DESCRIPTION
Fixes #231

This change will allow metric filters to use pre-existing log groups. It should be backwards compatible since `ResourceRef` extends `Token[String]`.