### PR TITLE
Fix RuleTarget bug by adding JsonString

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/JsonString.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/JsonString.scala
@@ -1,0 +1,24 @@
+package com.monsanto.arch.cloudformation.model
+
+import spray.json._
+
+/**
+  * CloudFormation has fields that are Json objects encoded as strings.
+  * This class simplifies the process of writing codecs for such types.
+  *
+  * I tried making the argument have type A with a JsonFormat type bound,
+  * but JsValue itself doesn't have an (identity) implicit defined, so
+  * that made the code awkward when I really wanted a raw JsValue.  I don't think it's
+  * too bad to have to call JsonString(foo.toJson), so I'm leaving it
+  * simple.  Suggestions welcome.
+  */
+final case class JsonString(value: JsValue)
+object JsonString {
+  implicit val format: JsonFormat[JsonString] = new JsonFormat[JsonString] {
+    override def read(json: JsValue): JsonString = json match {
+      case JsString(s) => JsonString(s.parseJson)
+      case _ => throw new RuntimeException(s"Not a JsString: ${json}")
+    }
+    override def write(obj: JsonString): JsValue = JsString(obj.value.compactPrint)
+  }
+}

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Events.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Events.scala
@@ -42,7 +42,7 @@ case class `AWS::Events::Rule`(name: String,
                                override val DependsOn: Option[Seq[String]] = None,
                                override val Condition: Option[ConditionRef] = None
                               ) extends Resource[`AWS::Events::Rule`] with HasArn {
-  
+
   require(EventPattern.isDefined || ScheduleExpression.isDefined, "AWS::Events::Rule must have either EventPattern and/or ScheduledExpression specified")
 
   def when(newCondition: Option[ConditionRef] = Condition): `AWS::Events::Rule` = copy(Condition = newCondition)
@@ -81,7 +81,7 @@ object `AWS::Events::Rule` extends DefaultJsonProtocol {
 case class RuleTarget(Arn: Token[String],
                       Id: String,
                       EcsParameters: Option[RuleEcsParameters] = None,
-                      Input: Option[JsValue] = None,
+                      Input: Option[JsonString] = None,
                       InputPath: Option[Token[String]] = None,
                       InputTransformer: Option[RuleInputTransformer] = None,
                       KinesisParameters: Option[RuleKinesisParameters] = None,

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/JsonString_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/JsonString_UT.scala
@@ -1,0 +1,20 @@
+package com.monsanto.arch.cloudformation.model
+
+import org.scalatest.{ FunSpec, Matchers }
+import spray.json._
+
+class JsonString_UT extends FunSpec with Matchers {
+  final case class Foo(x: Int, y: Boolean)
+  object Foo extends DefaultJsonProtocol {
+    implicit val format: JsonFormat[Foo] = jsonFormat2(apply)
+  }
+
+  describe("JsonString") {
+    it("serializes properly") {
+      val js = JsonString(Foo(5, true).toJson)
+      val expected = """"{\"x\":5,\"y\":true}""""
+      js.toJson.compactPrint shouldEqual expected
+      expected.parseJson.convertTo[JsonString] shouldEqual js
+    }
+  }
+}

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Events_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Events_UT.scala
@@ -1,0 +1,20 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model.JsonString
+import org.scalatest.{ FunSpec, Matchers }
+import spray.json._
+
+class Events_UT extends FunSpec with Matchers {
+  describe("RuleTarget") {
+    it("Should serialize") {
+      val t = RuleTarget(
+        Arn = "arn",
+        Id = "id",
+        Input = Some(JsonString(JsObject(
+          "a" -> JsNumber(5),
+          "b" -> JsBoolean(false)
+        ))))
+      t.toJson.compactPrint shouldEqual """{"Arn":"arn","Id":"id","Input":"{\"a\":5,\"b\":false}"}"""
+    }
+  }
+}


### PR DESCRIPTION
RuleTarget has an incorrect type for Input, with JsValue for Input when really
that needs to be a string-encoded JSON object.  This breaks serialization.  I
added a utility class JsonString to make the serialization smooth.  See the
comments on JsonString for more details.