### PR TITLE
Change Events::Rule target Input to Token[String]

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Events.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Events.scala
@@ -42,7 +42,7 @@ case class `AWS::Events::Rule`(name: String,
                                override val DependsOn: Option[Seq[String]] = None,
                                override val Condition: Option[ConditionRef] = None
                               ) extends Resource[`AWS::Events::Rule`] with HasArn {
-  
+
   require(EventPattern.isDefined || ScheduleExpression.isDefined, "AWS::Events::Rule must have either EventPattern and/or ScheduledExpression specified")
 
   def when(newCondition: Option[ConditionRef] = Condition): `AWS::Events::Rule` = copy(Condition = newCondition)
@@ -81,7 +81,7 @@ object `AWS::Events::Rule` extends DefaultJsonProtocol {
 case class RuleTarget(Arn: Token[String],
                       Id: String,
                       EcsParameters: Option[RuleEcsParameters] = None,
-                      Input: Option[JsValue] = None,
+                      Input: Option[Token[String]] = None,
                       InputPath: Option[Token[String]] = None,
                       InputTransformer: Option[RuleInputTransformer] = None,
                       KinesisParameters: Option[RuleKinesisParameters] = None,

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Events_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Events_UT.scala
@@ -1,0 +1,39 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model.{ Token, `Fn::Sub` }
+import org.scalatest.{ FunSpec, Matchers }
+import spray.json._
+
+class Events_UT extends FunSpec with Matchers {
+  describe("RuleTarget") {
+    it("Should serialize") {
+      val t = RuleTarget(
+        Arn = "arn",
+        Id = "id",
+        Input = Some(JsObject(
+          "a" -> JsNumber(5),
+          "b" -> JsBoolean(false)
+        ).compactPrint))
+      t.toJson.compactPrint shouldEqual
+        raw"""{"Arn":"arn","Id":"id","Input":"{\"a\":5,\"b\":false}"}"""
+    }
+
+    it("Should serialize sub") {
+      val sub: Token[String] =
+        `Fn::Sub`(
+          JsObject(
+            "a" -> JsString(raw"$${AWS::Region}"),
+            "b" -> JsString(raw"$${FOO}")
+          ).compactPrint,
+          Some(Map("FOO" -> "BAR"))
+        )
+      val t = RuleTarget(
+        Arn = "arn",
+        Id = "id",
+        Input = Some(sub)
+      )
+      t.toJson.compactPrint shouldEqual
+        raw"""{"Arn":"arn","Id":"id","Input":{"Fn::Sub":["{\"a\":\"$${AWS::Region}\",\"b\":\"$${FOO}\"}",{"FOO":"BAR"}]}}"""
+    }
+  }
+}


### PR DESCRIPTION
Fixes a serialization bug.  `JsValue` does not work.