### PR TITLE
Fix IAM Policies

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -187,44 +187,21 @@ object `AWS::IAM::Group` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::IAM::Group`] = jsonFormat7(`AWS::IAM::Group`.apply)
 }
 
-@implicitNotFound("you can only specify one of Groups, Roles, or Users")
-trait ValidPolicyCombo[G,R,U]
-object ValidPolicyCombo {
-  implicit object onlyG extends ValidPolicyCombo[Some[Seq[ResourceRef[`AWS::IAM::Group`]]], None.type, None.type]
-  implicit object onlyR extends ValidPolicyCombo[None.type, Some[Seq[ResourceRef[`AWS::IAM::Role`]]], None.type]
-  implicit object onlyU extends ValidPolicyCombo[None.type, None.type, Some[Seq[ResourceRef[`AWS::IAM::User`]]]]
-}
-
-case class `AWS::IAM::Policy` private (
+case class `AWS::IAM::Policy`(
   name:           String,
   PolicyDocument: PolicyDocument,
   PolicyName:     String,
-  Groups:         Option[Seq[ResourceRef[`AWS::IAM::Group`]]],
-  Roles:          Option[Seq[ResourceRef[`AWS::IAM::Role`]]],
-  Users:          Option[Seq[ResourceRef[`AWS::IAM::User`]]],
+  Groups:         Option[TokenSeq[String]] = None,
+  Roles:          Option[TokenSeq[String]] = None,
+  Users:          Option[TokenSeq[String]] = None,
   override val DependsOn: Option[Seq[String]] = None,
   override val Condition: Option[ConditionRef] = None
   ) extends Resource[`AWS::IAM::Policy`]{
+  require(Groups.nonEmpty || Roles.nonEmpty || Users.nonEmpty)
   def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
 }
 object `AWS::IAM::Policy` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::IAM::Policy`] = jsonFormat8(`AWS::IAM::Policy`.apply)
-
-  def from[
-    G <: Option[Seq[ResourceRef[`AWS::IAM::Group`]]],
-    R <: Option[Seq[ResourceRef[`AWS::IAM::Role`]]],
-    U <: Option[Seq[ResourceRef[`AWS::IAM::User`]]]
-  ](
-    name:           String,
-    PolicyDocument: PolicyDocument,
-    PolicyName:     String,
-    Groups:         G,
-    Roles:          R,
-    Users:          U,
-    DependsOn: Option[Seq[String]] = None,
-    Condition: Option[ConditionRef] = None
-  )(implicit ev1: ValidPolicyCombo[G,R,U]) =
-    new `AWS::IAM::Policy`(name, PolicyDocument, PolicyName, Groups, Roles, Users, DependsOn, Condition)
 }
 
 // TODO: Make this not a string

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Lambda.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Lambda.scala
@@ -6,7 +6,7 @@ import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 
 class Runtime(val runtime: String)
 
-@deprecated("Node v0.10.42 is currently marked as deprecated by AWS.")
+@deprecated("Node v0.10.42 is currently marked as deprecated by AWS.", "3.6.3")
 case object NodeJS extends Runtime("nodejs")
 
 case object `NodeJS4.3` extends Runtime("nodejs4.3")

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/IAMPolicy_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/IAMPolicy_UT.scala
@@ -1,6 +1,5 @@
 package com.monsanto.arch.cloudformation.model
 
-import com.monsanto.arch.cloudformation.model.resource.ValidPolicyCombo._
 import com.monsanto.arch.cloudformation.model.resource._
 import org.scalatest.{FunSpec, Matchers}
 
@@ -22,7 +21,7 @@ class IAMPolicy_UT extends FunSpec with Matchers with JsonWritingMatcher {
           ),
         Path = Some("/")
       )
-      val policyForRoles = `AWS::IAM::Policy`.from(
+      val policyForRoles = `AWS::IAM::Policy`(
         "S3GetPolicy",
         PolicyDocument(
           Statement = Seq(
@@ -123,6 +122,27 @@ class IAMPolicy_UT extends FunSpec with Matchers with JsonWritingMatcher {
           |    "Action": ["*"],
           |    "Resource": ["arn:1", "arn:2"]
           |  }]
+          |}
+        """.stripMargin
+    }
+
+    it("should allow existing IAM role") {
+      `AWS::IAM::Policy`(
+        name = "Foo",
+        PolicyDocument = PolicyDocument(Seq.empty),
+        PolicyName = "Foo",
+        Roles = Some(Seq("ExistingFoo"))
+      ) shouldMatch
+        """
+          |{
+          | "Type": "AWS::IAM::Policy",
+          | "Properties": {
+          |   "PolicyDocument": {
+          |     "Statement": []
+          |   },
+          |   "PolicyName": "Foo",
+          |   "Roles": ["ExistingFoo"]
+          | }
           |}
         """.stripMargin
     }


### PR DESCRIPTION
The existing Policy is incorrect for two reasons

- There is an incorrect constraint on Policies saying there can only be one of Users/Groups/Roles
- The type of Users/Groups/Roles is too restrictive, not allowing a caller to
  refer to an existing resource

I think the author may have meant to ensure there is at least one of
Users/Groups/Roles.  I added that as a require.
  
(This CR also fixes a trivial compilation warning.)