### PR TITLE
Upgrade/extend `AWS::Elasticsearch::Domain` to support VPCOptions

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticSearch.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ElasticSearch.scala
@@ -1,7 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model.{ConditionRef, Token}
-import spray.json.{DefaultJsonProtocol, JsonFormat}
+import spray.json.{DefaultJsonProtocol, JsonFormat, RootJsonFormat}
 
 case class EBSOptions(
   EBSEnabled:     Option[Token[Boolean]],
@@ -30,6 +30,15 @@ object SnapshotOptions extends DefaultJsonProtocol {
   implicit val format = jsonFormat1(SnapshotOptions.apply)
 }
 
+case class VPCOptions(
+                       SecurityGroupIds : Seq[Token[`AWS::EC2::SecurityGroup`]] = Seq.empty[Token[`AWS::EC2::SecurityGroup`]],
+                       SubnetIds: Seq[Token[String]]
+                     )
+
+object VPCOptions extends DefaultJsonProtocol {
+  implicit val format : RootJsonFormat[VPCOptions] = jsonFormat2(VPCOptions.apply)
+}
+
 case class `AWS::Elasticsearch::Domain` (
                                           name:                       String,
                                           DomainName:                 Token[String],
@@ -39,11 +48,13 @@ case class `AWS::Elasticsearch::Domain` (
                                           ElasticsearchClusterConfig: Option[ElasticsearchClusterConfig]    = None,
                                           ElasticsearchVersion:       Option[Token[String]]                 = None,
                                           SnapshotOptions:            Option[SnapshotOptions]               = None,
+                                          Tags:                       Option[Seq[AmazonTag]]                = None,
+                                          VPCOptions:                 Option[VPCOptions]                    = None,
                                           override val Condition:     Option[ConditionRef]                  = None,
                                           override val DependsOn:     Option[Seq[String]]                   = None
                                         ) extends Resource[`AWS::Elasticsearch::Domain`]{
-  def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
+  def when(newCondition: Option[ConditionRef] = Condition) : `AWS::Elasticsearch::Domain` = copy(Condition = newCondition)
 }
 object `AWS::Elasticsearch::Domain` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::Elasticsearch::Domain`] = jsonFormat10(`AWS::Elasticsearch::Domain`.apply)
+  implicit val format: JsonFormat[`AWS::Elasticsearch::Domain`] = jsonFormat12(`AWS::Elasticsearch::Domain`.apply)
 }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/BatchTest.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/BatchTest.scala
@@ -36,7 +36,7 @@ class BatchTest extends FunSpec with Matchers {
         State = Some(ComputeEnvironmentState.ENABLED)
       )
 
-      theEnv.toJson.prettyPrint shouldBe """{
+      theEnv.toJson shouldBe """{
                                            |  "name": "bob",
                                            |  "ServiceRole": {
                                            |    "Ref": "bob-role"
@@ -59,7 +59,7 @@ class BatchTest extends FunSpec with Matchers {
                                            |  },
                                            |  "State": "ENABLED",
                                            |  "Type": "MANAGED"
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
     }
 
   }
@@ -89,7 +89,7 @@ class BatchTest extends FunSpec with Matchers {
         RetryStrategy = JobRetryStrategy(Attempts = Some(7))
       )
 
-      theDef.toJson.prettyPrint shouldBe """{
+      theDef.toJson shouldBe """{
                                            |  "name": "bob",
                                            |  "ContainerProperties": {
                                            |    "Environment": [{
@@ -113,7 +113,7 @@ class BatchTest extends FunSpec with Matchers {
                                            |    "someParam": "hallo"
                                            |  },
                                            |  "Type": "container"
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
     }
 
   }
@@ -132,7 +132,7 @@ class BatchTest extends FunSpec with Matchers {
         State = Some(JobQueueState.ENABLED)
       )
 
-      theQueue.toJson.prettyPrint shouldBe """{
+      theQueue.toJson shouldBe """{
                                              |  "name": "bobq",
                                              |  "ComputeEnvironmentOrder": [{
                                              |    "ComputeEnvironment": "abc",
@@ -144,7 +144,7 @@ class BatchTest extends FunSpec with Matchers {
                                              |  "JobQueueName": "bobqueue",
                                              |  "Priority": 7,
                                              |  "State": "ENABLED"
-                                             |}""".stripMargin
+                                             |}""".stripMargin.parseJson
     }
 
   }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/EFS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/EFS_UT.scala
@@ -27,7 +27,7 @@ class EFS_UT extends FunSpec with Matchers {
     )
 
     it("should serialize to JSON") {
-      resource.toJson.prettyPrint shouldBe """{
+      resource.toJson shouldBe """{
                                              |  "name": "test",
                                              |  "KmsKeyId": {
                                              |    "Ref": "test"
@@ -38,7 +38,7 @@ class EFS_UT extends FunSpec with Matchers {
                                              |    "Key": "Foo",
                                              |    "Value": "Bar"
                                              |  }]
-                                             |}""".stripMargin
+                                             |}""".stripMargin.parseJson
     }
 
     it("throws an exception when KmsKeyId is set but Encrypted is false") {
@@ -76,7 +76,7 @@ class EFS_UT extends FunSpec with Matchers {
       SubnetId = ResourceRef(subnet)
     )
     it("should serialize to JSON") {
-      resource.toJson.prettyPrint shouldBe """{
+      resource.toJson shouldBe """{
                                              |  "name": "test",
                                              |  "SecurityGroups": [{
                                              |    "Ref": "test"
@@ -88,7 +88,7 @@ class EFS_UT extends FunSpec with Matchers {
                                              |  "SubnetId": {
                                              |    "Ref": "test"
                                              |  }
-                                             |}""".stripMargin
+                                             |}""".stripMargin.parseJson
     }
   }
 }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ElasticSearchDomain_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ElasticSearchDomain_UT.scala
@@ -1,0 +1,34 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model.UNSAFEToken
+import org.scalatest.{FunSpec, Matchers}
+import spray.json._
+
+class ElasticSearchDomain_UT extends FunSpec with Matchers {
+  describe("An Elasticsearch::Domain") {
+    it("should be serialize correctly") {
+      val domain = `AWS::Elasticsearch::Domain`(
+        name="testdomain",
+        DomainName="testDomainName",
+        Tags=Some(Seq(AmazonTag("testkey", "testValue"))),
+        VPCOptions = Some(VPCOptions(Seq(UNSAFEToken("sg-1234567")), Seq("subnet-f1234567")))
+      )
+
+      val result = """{
+                     |  "name": "testdomain",
+                     |  "DomainName": "testDomainName",
+                     |  "Tags": [{
+                     |    "Key": "testkey",
+                     |    "Value": "testValue"
+                     |  }],
+                     |  "VPCOptions": {
+                     |    "SecurityGroupIds": ["sg-1234567"],
+                     |    "SubnetIds": ["subnet-f1234567"]
+                     |  }
+                     |}""".stripMargin.parseJson
+
+      domain.toJson shouldBe result
+    }
+  }
+}
+

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/SSM_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/SSM_UT.scala
@@ -15,13 +15,13 @@ class SSM_UT extends FunSpec with Matchers {
         DocumentType.Command
       )
 
-      doc.toJson.prettyPrint shouldBe """{
+      doc.toJson shouldBe """{
                                         |  "name": "cfname",
                                         |  "Content": {
                                         |    "schemaVersion": "2.2"
                                         |  },
                                         |  "DocumentType": "Command"
-                                        |}""".stripMargin
+                                        |}""".stripMargin.parseJson
     }
 
     it("should serialize the whole mess") {
@@ -61,7 +61,7 @@ class SSM_UT extends FunSpec with Matchers {
         DocumentType.Command
       )
 
-      doc.toJson.prettyPrint shouldBe """{
+      doc.toJson shouldBe """{
                                         |  "name": "cfname",
                                         |  "Content": {
                                         |    "schemaVersion": "2.2",
@@ -103,7 +103,7 @@ class SSM_UT extends FunSpec with Matchers {
                                         |    }]
                                         |  },
                                         |  "DocumentType": "Command"
-                                        |}""".stripMargin
+                                        |}""".stripMargin.parseJson
     }
 
     describe("helper constructors should construct the correct doc type and schema") {
@@ -147,10 +147,10 @@ class SSM_UT extends FunSpec with Matchers {
         mainSteps = None
       )
 
-      content.toJson.prettyPrint shouldBe """{
+      content.toJson shouldBe """{
                                             |  "schemaVersion": "2.2",
                                             |  "description": "this is the stuff"
-                                            |}""".stripMargin
+                                            |}""".stripMargin.parseJson
     }
 
     it("DocumentParameter should serialize most basic content") {
@@ -162,13 +162,13 @@ class SSM_UT extends FunSpec with Matchers {
         allowedValues = Some(Seq("hello", "goodbye"))
       )
 
-      param.toJson.prettyPrint shouldBe """{
+      param.toJson shouldBe """{
                                           |  "description": "some parameter",
                                           |  "allowedValues": ["hello", "goodbye"],
                                           |  "default": "hello",
                                           |  "type": "String",
                                           |  "allowedPattern": ".*"
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
 
     it("DocumentStep should serialize most basic content") {
@@ -179,10 +179,10 @@ class SSM_UT extends FunSpec with Matchers {
         inputs = None
       )
 
-      step.toJson.prettyPrint shouldBe """{
+      step.toJson shouldBe """{
                                          |  "action": "aws:something",
                                          |  "name": "stepName"
-                                         |}""".stripMargin
+                                         |}""".stripMargin.parseJson
     }
 
     it("DocumentStep should fail construction if name includes a space") {
@@ -207,7 +207,7 @@ class SSM_UT extends FunSpec with Matchers {
           precondition = Some(Precondition.PlatformTypeWindows)
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:applications",
                                            |  "name": "stepName",
                                            |  "precondition": {
@@ -219,7 +219,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |    "source": "somewhere",
                                            |    "sourceHash": "abc123"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:configureDocker") {
@@ -229,7 +229,7 @@ class SSM_UT extends FunSpec with Matchers {
           precondition = Some(Precondition.PlatformTypeLinux)
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:configureDocker",
                                            |  "name": "stepName",
                                            |  "precondition": {
@@ -238,7 +238,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |  "inputs": {
                                            |    "action": "Install"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:configurePackage") {
@@ -249,7 +249,7 @@ class SSM_UT extends FunSpec with Matchers {
           version = Some("1.2.3")
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:configurePackage",
                                            |  "name": "stepName",
                                            |  "inputs": {
@@ -257,7 +257,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |    "action": "Uninstall",
                                            |    "version": "1.2.3"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:refreshAssociation") {
@@ -266,13 +266,13 @@ class SSM_UT extends FunSpec with Matchers {
           associationIds = "abc123,def456,ghi789"
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:refreshAssociation",
                                            |  "name": "stepName",
                                            |  "inputs": {
                                            |    "associationIds": "abc123,def456,ghi789"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:runDockerAction") {
@@ -290,7 +290,7 @@ class SSM_UT extends FunSpec with Matchers {
           publish = Some("port config")
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:runDockerAction",
                                            |  "name": "stepName",
                                            |  "inputs": {
@@ -305,7 +305,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |    "env": "env config",
                                            |    "memory": "mem config"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:runShellScript") {
@@ -316,7 +316,7 @@ class SSM_UT extends FunSpec with Matchers {
           workingDirectory = Some("/tmp")
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:runShellScript",
                                            |  "name": "stepName",
                                            |  "inputs": {
@@ -324,7 +324,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |    "timeoutSeconds": "1",
                                            |    "workingDirectory": "/tmp"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:softwareInventory") {
@@ -337,7 +337,7 @@ class SSM_UT extends FunSpec with Matchers {
           customInventory = Some("custominventory-value")
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:softwareInventory",
                                            |  "name": "stepName",
                                            |  "inputs": {
@@ -347,7 +347,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |    "customInventory": "custominventory-value",
                                            |    "awsComponents": "awscomponents-value"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
 
       it("aws:updateSsmAgent") {
@@ -357,7 +357,7 @@ class SSM_UT extends FunSpec with Matchers {
           targetVersion = Some("1.2.3")
         )
 
-        step.toJson.prettyPrint shouldBe """{
+        step.toJson shouldBe """{
                                            |  "action": "aws:updateSsmAgent",
                                            |  "name": "stepName",
                                            |  "inputs": {
@@ -366,7 +366,7 @@ class SSM_UT extends FunSpec with Matchers {
                                            |    "source": "https://s3.{Region}.amazonaws.com/amazon-ssm-{Region}/ssm-agent-manifest.json",
                                            |    "targetVersion": "1.2.3"
                                            |  }
-                                           |}""".stripMargin
+                                           |}""".stripMargin.parseJson
       }
     }
   }
@@ -417,7 +417,7 @@ class SSM_UT extends FunSpec with Matchers {
         Targets = None
       )
 
-      assoc.toJson.prettyPrint shouldBe """{
+      assoc.toJson shouldBe """{
                                           |  "name": "cfname",
                                           |  "Name": "AssociationName",
                                           |  "Parameters": {
@@ -426,7 +426,7 @@ class SSM_UT extends FunSpec with Matchers {
                                           |  "DocumentVersion": "1",
                                           |  "InstanceId": "i-7893456789345",
                                           |  "ScheduleExpression": "cron(* * * * * *)"
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
 
     it("should serialize an association for a managed document") {
@@ -448,7 +448,7 @@ class SSM_UT extends FunSpec with Matchers {
         Targets = None
       )
 
-      assoc.toJson.prettyPrint shouldBe """{
+      assoc.toJson shouldBe """{
                                           |  "name": "cfname",
                                           |  "Name": {
                                           |    "Ref": "cfname"
@@ -459,7 +459,7 @@ class SSM_UT extends FunSpec with Matchers {
                                           |  "DocumentVersion": "1",
                                           |  "InstanceId": "i-7893456789345",
                                           |  "ScheduleExpression": "rate(3 days)"
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
 
     it("should serialize an association with InstanceIds targets") {
@@ -479,7 +479,7 @@ class SSM_UT extends FunSpec with Matchers {
         ))
       )
 
-      assoc.toJson.prettyPrint shouldBe """{
+      assoc.toJson shouldBe """{
                                           |  "name": "cfname",
                                           |  "Name": "AssociationName",
                                           |  "Parameters": {
@@ -491,7 +491,7 @@ class SSM_UT extends FunSpec with Matchers {
                                           |    "Key": "InstanceIds",
                                           |    "Values": ["i-3457894578945"]
                                           |  }]
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
 
     it("should serialize an association with tag targets") {
@@ -511,7 +511,7 @@ class SSM_UT extends FunSpec with Matchers {
         ))
       )
 
-      assoc.toJson.prettyPrint shouldBe """{
+      assoc.toJson shouldBe """{
                                           |  "name": "cfname",
                                           |  "Name": "AssociationName",
                                           |  "Parameters": {
@@ -523,7 +523,7 @@ class SSM_UT extends FunSpec with Matchers {
                                           |    "Key": "tag:someTag",
                                           |    "Values": ["someValue"]
                                           |  }]
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
   }
 
@@ -539,13 +539,13 @@ class SSM_UT extends FunSpec with Matchers {
         "value"
       )
 
-      param.toJson.prettyPrint shouldBe """{
+      param.toJson shouldBe """{
                                           |  "name": "cfname",
                                           |  "Name": "ssmname",
                                           |  "Description": "this is a parameter",
                                           |  "Value": "value",
                                           |  "Type": "String"
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
 
     it("should serialize a StringList type") {
@@ -557,13 +557,13 @@ class SSM_UT extends FunSpec with Matchers {
         "value1,value2"
       )
 
-      param.toJson.prettyPrint shouldBe """{
+      param.toJson shouldBe """{
                                           |  "name": "cfname",
                                           |  "Name": "ssmname",
                                           |  "Description": "this is a parameter",
                                           |  "Value": "value1,value2",
                                           |  "Type": "StringList"
-                                          |}""".stripMargin
+                                          |}""".stripMargin.parseJson
     }
   }
 }


### PR DESCRIPTION
- Add support for VPCOptions. This allows you to make your elastic search domain privately accessible.
- Add the ability to attach tags to elastic search domain.
- Added unit test.
- Tests did not work for me (possibly windows with \r\n?). Now comparing actual json's instead of pretty printed jsons.

Should be backwards compatible.