### PR TITLE
Add support for custom CF resource calls

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
@@ -2,7 +2,7 @@ package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model.Token.TokenSeq
 import com.monsanto.arch.cloudformation.model._
-import spray.json.JsonFormat
+import spray.json.{JsObject, JsValue, JsonFormat, RootJsonFormat, RootJsonWriter}
 
 /**
   * Created by bkrodg on 1/13/16.
@@ -60,4 +60,36 @@ object `AWS::CloudFormation::Stack` {
 
   implicit val format: JsonFormat[`AWS::CloudFormation::Stack`] = jsonFormat7(
       `AWS::CloudFormation::Stack`.apply)
+}
+
+case class `AWS::CloudFormation::CustomResource`(name: String,
+                                                 ServiceToken: Token[String],
+                                                 Parameters: Option[Map[String, JsValue]] = None,
+                                                 CustomResourceTypeName: Option[String] = None,
+                                                 override val DependsOn: Option[Seq[String]] = None,
+                                                 override val Condition: Option[ConditionRef] = None
+                                                )
+  extends Resource[`AWS::CloudFormation::CustomResource`] {
+  def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
+  override val ResourceType = CustomResourceTypeName match {
+    case None => "AWS::CloudFormation::CustomResource"
+    case Some(x) => if (x.startsWith("Custom::")) x else (s"Custom::${x}")
+  }
+}
+
+object `AWS::CloudFormation::CustomResource` extends spray.json.DefaultJsonProtocol {
+
+  import spray.json.DefaultJsonProtocol._
+  import Token._
+  implicit val format: RootJsonFormat[`AWS::CloudFormation::CustomResource`] = new RootJsonFormat[`AWS::CloudFormation::CustomResource`] {
+    override def read(json: JsValue): `AWS::CloudFormation::CustomResource` = ???
+
+    override def write(obj: `AWS::CloudFormation::CustomResource`): JsValue = {
+      val st = ("ServiceToken" -> implicitly[JsonFormat[Token[String]]].write(obj.ServiceToken))
+      obj.Parameters match {
+        case Some(p) => JsObject(p + st)
+        case None => JsObject(st)
+      }
+    }
+  }
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
@@ -69,9 +69,7 @@ case class JsonableWrapper[T: JsonFormat](thing: T) {
 object JsonableWrapper {
   import scala.language.implicitConversions
 
-  implicit def fmt[T] = new JsonFormat[JsonableWrapper[T]] {
-    override def read(json: JsValue): JsonableWrapper[T] = ???
-
+  implicit def fmt[T] = new JsonWriter[JsonableWrapper[T]] {
     override def write(obj: JsonableWrapper[T]): JsValue = obj.fmt.write(obj.thing)
   }
 

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
@@ -1,0 +1,146 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model.{ParameterRef, StringParameter, Template}
+import org.scalatest.{FunSpec, Matchers}
+import spray.json._
+
+class CloudFormation_UT extends FunSpec with Matchers{
+
+  describe("No args, no special title"){
+    it ("should serialize as expected") {
+
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = "TestToken"
+      )
+
+      println(Template.fromResource(customResource).toJson)
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": "TestToken"
+          |      },
+          |      "Type": "AWS::CloudFormation::CustomResource"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+  describe("Parameter for service token"){
+    it ("should serialize as expected") {
+
+      val param = StringParameter(
+        name = "TestParam"
+      )
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = ParameterRef(param)
+      )
+
+      println(Template.fromResource(customResource).toJson)
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": {"Ref": "TestParam"}
+          |      },
+          |      "Type": "AWS::CloudFormation::CustomResource"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+
+
+  describe("Custom type"){
+    it ("should serialize as expected") {
+
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = "TestToken",
+        CustomResourceTypeName = Some("HeyThere")
+      )
+
+      println(Template.fromResource(customResource).toJson)
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": "TestToken"
+          |      },
+          |      "Type": "Custom::HeyThere"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+  describe("Custom type with Custom included"){
+    it ("should serialize as expected") {
+
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = "TestToken",
+        CustomResourceTypeName = Some("Custom::HeyThere")
+      )
+
+      println(Template.fromResource(customResource).toJson)
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": "TestToken"
+          |      },
+          |      "Type": "Custom::HeyThere"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+
+  describe("String parameter"){
+    it ("should serialize as expected") {
+
+      import DefaultJsonProtocol._
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = "TestToken",
+        Parameters = Some(Map("Hi" -> "There".toJson))
+      )
+
+      println(Template.fromResource(customResource).toJson)
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": "TestToken",
+          |        "Hi": "There"
+          |      },
+          |      "Type": "AWS::CloudFormation::CustomResource"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+
+}

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
@@ -121,7 +121,7 @@ class CloudFormation_UT extends FunSpec with Matchers{
       val customResource = `AWS::CloudFormation::CustomResource`(
         name = "TestResource",
         ServiceToken = "TestToken",
-        Parameters = Some(Map("Hi" -> "There".toJson))
+        Parameters = Some(Map("Hi" -> "There"))
       )
 
       println(Template.fromResource(customResource).toJson)

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
@@ -143,4 +143,36 @@ class CloudFormation_UT extends FunSpec with Matchers{
     }
   }
 
+  describe("String and number parameter"){
+    it ("should serialize as expected") {
+
+      import DefaultJsonProtocol._
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = "TestToken",
+        Parameters = Some(Map(
+          "Hi" -> "There",
+          "Number" -> 1))
+      )
+
+      println(Template.fromResource(customResource).toJson)
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": "TestToken",
+          |        "Hi": "There",
+          |        "Number": 1
+          |      },
+          |      "Type": "AWS::CloudFormation::CustomResource"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+
 }


### PR DESCRIPTION
I'm not sure if my JsonableWrapper thing is the cleanest way to make this work, but it was the best I came up with for wanting to allow for a map of String -> AnythingThatCanBeWrittenToJson.  I don't think there's any way to define the Map's value type with a context bound or anything like that.  