### PR TITLE
Handle template addition for Description and AWSTemplateFormatVersion

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
@@ -67,15 +67,18 @@ case class Template(
     if(s1.isEmpty && s2.isEmpty) None
     else Some(s1.getOrElse(Seq.empty[T]) ++ s2.getOrElse(Seq.empty[T]))
 
+  private def mergeOption[T](s1: Option[T], s2: Option[T]): Option[T] =
+    if (s2.isDefined) s2 else s1
+
   def ++(t: Template) = Template(
-    Description flatMap (_ + t.Description.getOrElse("")),
+    mergeOption(Description, t.Description),
     mergeOptionSeq(Parameters, t.Parameters ),
     mergeOptionSeq(Conditions, t.Conditions ),
     mergeOptionSeq(Mappings,   t.Mappings   ),
     Resources ++ t.Resources,
     mergeOptionSeq(Routables,  t.Routables  ),
     mergeOptionSeq(Outputs,    t.Outputs    ),
-    this.AWSTemplateFormatVersion
+    mergeOption(AWSTemplateFormatVersion, t.AWSTemplateFormatVersion)
   )
 }
 object Template extends DefaultJsonProtocol {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/Template_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/Template_UT.scala
@@ -188,4 +188,38 @@ class Template_UT extends FlatSpec with Matchers with VPC with Subnet with Avail
     val template = Template.EMPTY ++ outputs
     template should equal(Template.EMPTY.copy(Outputs = Some(outputs)))
   }
+
+  it should "take description 1 if description 2 is None" in {
+    val template1 = Template(Description = Some("1"), Resources = Seq.empty)
+    val template2 = Template(Description = None, Resources = Seq.empty)
+    (template1 ++ template2).Description should equal (Some("1"))
+  }
+
+  it should "take description 2 if description 1 is None" in {
+    val template1 = Template(Description = None, Resources = Seq.empty)
+    val template2 = Template(Description = Some("2"), Resources = Seq.empty)
+    (template1 ++ template2).Description should equal (Some("2"))
+  }
+  it should "take description 2 if description 1 is set" in {
+    val template1 = Template(Description = Some("1"), Resources = Seq.empty)
+    val template2 = Template(Description = Some("2"), Resources = Seq.empty)
+    (template1 ++ template2).Description should equal (Some("2"))
+  }
+
+  it should "take version 1 if version 2 is None" in {
+    val template1 = Template(AWSTemplateFormatVersion = Some("1"), Resources = Seq.empty)
+    val template2 = Template(AWSTemplateFormatVersion = None, Resources = Seq.empty)
+    (template1 ++ template2).AWSTemplateFormatVersion should equal (Some("1"))
+  }
+
+  it should "take version 2 if version 1 is None" in {
+    val template1 = Template(AWSTemplateFormatVersion = None, Resources = Seq.empty)
+    val template2 = Template(AWSTemplateFormatVersion = Some("2"), Resources = Seq.empty)
+    (template1 ++ template2).AWSTemplateFormatVersion should equal (Some("2"))
+  }
+  it should "take version 2 if version 1 is set" in {
+    val template1 = Template(AWSTemplateFormatVersion = Some("1"), Resources = Seq.empty)
+    val template2 = Template(AWSTemplateFormatVersion = Some("2"), Resources = Seq.empty)
+    (template1 ++ template2).AWSTemplateFormatVersion should equal (Some("2"))
+  }
 }


### PR DESCRIPTION
Now that these are options, we should handle template addition by looking at the two and preserving left if right is None.