### PR TITLE
Amiid deprecation

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -1,6 +1,6 @@
 package com.monsanto.arch.cloudformation.model
 
-import com.monsanto.arch.cloudformation.model.resource.Resource
+import com.monsanto.arch.cloudformation.model.resource.{AMIId, Resource}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -146,7 +146,7 @@ case class `Fn::Split`(delimiterChar: String, toSplit: Token[String])
 }
 
 case class `Fn::FindInMap`[R](mapName: Token[MappingRef[R]], outerKey: Token[String], innerKey: Token[String])
-  extends AmazonFunctionCall[R]("Fn::FindInMap"){type CFBackingType = (Token[MappingRef[_]], Token[String], Token[String]); val arguments = (mapName.asInstanceOf[Token[MappingRef[_]]], outerKey, innerKey)}
+  extends AmazonFunctionCall[String]("Fn::FindInMap"){type CFBackingType = (Token[MappingRef[_]], Token[String], Token[String]); val arguments = (mapName.asInstanceOf[Token[MappingRef[_]]], outerKey, innerKey)}
 
 case class `Fn::Base64`(toEncode: Token[String])
   extends AmazonFunctionCall[String]("Fn::Base64"){type CFBackingType = Token[String] ; val arguments = toEncode}

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -153,6 +153,11 @@ case class `Fn::Base64`(toEncode: Token[String])
 
 case class `Fn::ImportValue`(importValue: Token[String])
   extends AmazonFunctionCall[String]("Fn::ImportValue"){type CFBackingType = Token[String] ; val arguments = importValue}
+object `Fn::ImportValue` {
+  implicit def fmt: JsonWriter[`Fn::ImportValue`] = new JsonWriter[`Fn::ImportValue`] {
+    override def write(obj: `Fn::ImportValue`): JsValue = AmazonFunctionCall.format.write(obj)
+  }
+}
 
 case class `Fn::Sub`(template: Token[String], subs: Option[Map[Token[String], Token[String]]] = None)
   extends AmazonFunctionCall[String]("Fn::Sub"){
@@ -161,6 +166,12 @@ case class `Fn::Sub`(template: Token[String], subs: Option[Map[Token[String], To
   def serializeArguments = arguments._2 match {
     case Some(x) => arguments.toJson
     case None => arguments._1.toJson
+  }
+}
+
+object `Fn::Sub` {
+  implicit def fmt: JsonWriter[`Fn::Sub`] = new JsonWriter[`Fn::Sub`] {
+    override def write(obj: `Fn::Sub`): JsValue = AmazonFunctionCall.format.write(obj)
   }
 }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AmazonTag.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AmazonTag.scala
@@ -11,7 +11,18 @@ case class AmazonTag(Key: String, Value: Token[String], PropagateAtLaunch: Optio
 object AmazonTag extends DefaultJsonProtocol {
   implicit val format: JsonFormat[AmazonTag] = jsonFormat3(AmazonTag.apply)
 
-  def fromName(name: String) = Seq(AmazonTag("Name", `Fn::Join`("-", Seq(name, `AWS::StackName`))))
+  def fromName(name: String): Seq[AmazonTag] = Seq(AmazonTag("Name", `Fn::Sub`(s"$${AWS::StackName}-${name}")))
+
+  def fromName(name: Option[String]): Seq[AmazonTag] =
+    name match {
+      case Some(n) => fromName(n)
+      case None => stackName()
+    }
+
   def fromNamePropagate(resourceName: String) =
-    Seq(AmazonTag("Name", `Fn::Join`("-", Seq(resourceName, `AWS::StackName`)), PropagateAtLaunch = Some(true)))
+    Seq(AmazonTag("Name", `Fn::Sub`(s"$${AWS::StackName}-${resourceName}"), PropagateAtLaunch = Some(true)))
+
+  // For anything where just tagging it with the stack name makes sense.
+  def stackName() = Seq(AmazonTag("Name", `Fn::Sub`(s"$${AWS::StackName}")))
+
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AutoScaling.scala
@@ -32,7 +32,7 @@ object `AWS::AutoScaling::AutoScalingGroup` extends DefaultJsonProtocol {
 
 case class `AWS::AutoScaling::LaunchConfiguration`(
     name:               String,
-    ImageId:            Token[AMIId],
+    ImageId:            Token[String],
     InstanceType:       Token[String],
     KeyName:            Token[String],
     SecurityGroups:     Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EC2.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EC2.scala
@@ -65,12 +65,15 @@ object `AWS::EC2::EIPAssociation` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::EC2::EIPAssociation`] = jsonFormat5(`AWS::EC2::EIPAssociation`.apply)
 }
 
+@deprecated(since = "3.8.2", message = "Changed to just use Token[String].  The AMIId wrapper added little value and made it more difficult to look AMIs up from a custom Lambda.")
 case class AMIId(id: String)
 object AMIId extends DefaultJsonProtocol {
   implicit val format: JsonFormat[AMIId] = new JsonFormat[AMIId] {
     def write(obj: AMIId) = JsString(obj.id)
     def read(json: JsValue) = AMIId(json.convertTo[String])
   }
+  implicit def convertToString(ami: AMIId): String = ami.id
+  implicit def convertToTokenString(ami: AMIId): Token[String] = ami.id
 }
 
 case class EC2MountPoint(Device: String, VolumeId: Token[String])
@@ -83,7 +86,7 @@ case class `AWS::EC2::Instance`(
   InstanceType:           Token[String],
   KeyName:                Token[String],
   SubnetId:               Token[ResourceRef[`AWS::EC2::Subnet`]],
-  ImageId:                Token[AMIId],
+  ImageId:                Token[String],
   Tags:                   Seq[AmazonTag],
   SecurityGroupIds:       Seq[ResourceRef[`AWS::EC2::SecurityGroup`]] = Seq.empty[ResourceRef[`AWS::EC2::SecurityGroup`]],
   Metadata:               Option[Map[String, String]] = None,

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
@@ -298,7 +298,6 @@ trait Autoscaling {
       elbs:        Option[Seq[Token[ResourceRef[`AWS::ElasticLoadBalancing::LoadBalancer`]]]] = None
     )(implicit vpc: `AWS::EC2::VPC`) = {
 
-      val resourceName = baseName + "LaunchConfig"
       val asgName = baseName + "AutoScale"
 
       val launchConfigSGR @ SecurityGroupRoutable(aLaunchConfig, _, _) =
@@ -514,7 +513,7 @@ trait Gateway {
     val gName = "InternetGateway"
     val gateway = `AWS::EC2::InternetGateway`(
       gName,
-      Tags = AmazonTag.fromName(gName)
+      Tags = AmazonTag.stackName()
     )
 
     val attName = "GatewayToInternet"
@@ -531,10 +530,12 @@ trait Gateway {
 trait VPC extends Outputs {
   implicit class RichVPC(vpc: `AWS::EC2::VPC`)
 
-  def withVpc(cidrBlock: Token[CidrBlock])(f: (`AWS::EC2::VPC`) => Template): Template = {
-    val vpcName = "VPC"
+  def withVpc(cidrBlock: Token[CidrBlock], vpcName: Option[String] = None)(f: (`AWS::EC2::VPC`) => Template): Template = {
     val vpc = `AWS::EC2::VPC`(
-      vpcName,
+      vpcName match {
+        case Some(n) => n
+        case None => "VPC"
+      },
       CidrBlock = cidrBlock,
       Tags = AmazonTag.fromName(vpcName),
       EnableDnsSupport = true,

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
@@ -254,7 +254,7 @@ trait Autoscaling {
 
   def launchConfig(
     name:         String,
-    image:        Token[AMIId],
+    image:        Token[String],
     instanceType: Token[String],
     keyName:      Token[String],
     sgs:          Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
@@ -279,7 +279,7 @@ trait Autoscaling {
 
   def asg(
       baseName:     String,
-      image:        Token[AMIId],
+      image:        Token[String],
       instanceType: Token[String],
       keyName:      Token[String],
       sgs:          Seq[Token[ResourceRef[`AWS::EC2::SecurityGroup`]]],
@@ -556,7 +556,7 @@ trait EC2 {
     name:                  String,
     InstanceType:          Token[String],
     KeyName:               Token[String],
-    ImageId:               Token[AMIId],
+    ImageId:               Token[String],
     SecurityGroupIds:      Seq[ResourceRef[`AWS::EC2::SecurityGroup`]],
     Tags:                  Seq[AmazonTag],
     Metadata:              Option[Map[String, String]]                             = None,

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation_UT.scala
@@ -1,6 +1,6 @@
 package com.monsanto.arch.cloudformation.model.resource
 
-import com.monsanto.arch.cloudformation.model.{ParameterRef, StringParameter, Template}
+import com.monsanto.arch.cloudformation.model._
 import org.scalatest.{FunSpec, Matchers}
 import spray.json._
 
@@ -159,6 +159,73 @@ class CloudFormation_UT extends FunSpec with Matchers{
           |        "ServiceToken": "TestToken",
           |        "Hi": "There",
           |        "Number": 1
+          |      },
+          |      "Type": "AWS::CloudFormation::CustomResource"
+          |    }
+          |  }
+          |}
+        """.stripMargin.parseJson
+      Template.fromResource(customResource).toJson should be (expectedJson)
+    }
+  }
+
+  // This doesn't work yet, but it should be fixed.
+//  describe("pseudo parameter"){
+//    it ("should serialize as expected") {
+//
+//      import DefaultJsonProtocol._
+//      val customResource = `AWS::CloudFormation::CustomResource`(
+//        name = "TestResource",
+//        ServiceToken = "TestToken",
+//        Parameters = Some(Map(
+//          "AmiNamePrefix" -> "mon-amzn-2",
+//          "Region" -> JsonWritable(`AWS::Region`)
+//        ))
+//      )
+//
+//      val expectedJson =
+//        """
+//          |{
+//          |  "Resources": {
+//          |    "TestResource": {
+//          |      "Properties": {
+//          |        "ServiceToken": "TestToken",
+//          |        "AmiNamePrefix": "mon-amzn-2",
+//          |        "Region": {"Ref":"AWS::Region"}
+//          |      },
+//          |      "Type": "AWS::CloudFormation::CustomResource"
+//          |    }
+//          |  }
+//          |}
+//        """.stripMargin.parseJson
+//      Template.fromResource(customResource).toJson should be (expectedJson)
+//    }
+//  }
+
+  describe("function"){
+    it ("should serialize as expected") {
+
+      import AmazonFunctionCall._
+
+
+      val customResource = `AWS::CloudFormation::CustomResource`(
+        name = "TestResource",
+        ServiceToken = "TestToken",
+        Parameters = Some(Map(
+          "AmiNamePrefix" -> "mon-amzn-2",
+          "Region" -> `Fn::Sub`("${AWS::Region}")
+        ))
+      )
+
+      val expectedJson =
+        """
+          |{
+          |  "Resources": {
+          |    "TestResource": {
+          |      "Properties": {
+          |        "ServiceToken": "TestToken",
+          |        "AmiNamePrefix": "mon-amzn-2",
+          |        "Region": {"Fn::Sub":"${AWS::Region}"}
           |      },
           |      "Type": "AWS::CloudFormation::CustomResource"
           |    }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
@@ -348,13 +348,7 @@ class RDS_UT extends FunSpec with Matchers {
             "StorageType" -> JsString("gp2"),
             "Tags" -> JsArray(JsObject(
               "Key" -> JsString("Name"),
-              "Value" -> JsObject("Fn::Join" -> JsArray(
-                JsString("-"),
-                JsArray(
-                  JsString(dbName),
-                  JsObject("Ref" -> JsString("AWS::StackName"))
-                )
-              ))
+              "Value" -> JsObject("Fn::Sub" -> JsString(s"$${AWS::StackName}-${dbName}"))
             ))
           )
         )


### PR DESCRIPTION
Changed to just use Token[String].  The AMIId wrapper added little value and made it more difficult to look AMIs up from a custom Lambda.

This change also adds some implicit conversion helpers.