### PR TITLE
Switched fromName tag generator to put the stack name first.

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AmazonTag.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/AmazonTag.scala
@@ -11,7 +11,18 @@ case class AmazonTag(Key: String, Value: Token[String], PropagateAtLaunch: Optio
 object AmazonTag extends DefaultJsonProtocol {
   implicit val format: JsonFormat[AmazonTag] = jsonFormat3(AmazonTag.apply)
 
-  def fromName(name: String) = Seq(AmazonTag("Name", `Fn::Join`("-", Seq(name, `AWS::StackName`))))
+  def fromName(name: String): Seq[AmazonTag] = Seq(AmazonTag("Name", `Fn::Sub`(s"$${AWS::StackName}-${name}")))
+
+  def fromName(name: Option[String]): Seq[AmazonTag] =
+    name match {
+      case Some(n) => fromName(n)
+      case None => stackName()
+    }
+
   def fromNamePropagate(resourceName: String) =
-    Seq(AmazonTag("Name", `Fn::Join`("-", Seq(resourceName, `AWS::StackName`)), PropagateAtLaunch = Some(true)))
+    Seq(AmazonTag("Name", `Fn::Sub`(s"$${AWS::StackName}-${resourceName}"), PropagateAtLaunch = Some(true)))
+
+  // For anything where just tagging it with the stack name makes sense.
+  def stackName() = Seq(AmazonTag("Name", `Fn::Sub`(s"$${AWS::StackName}")))
+
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/simple/Builders.scala
@@ -298,7 +298,6 @@ trait Autoscaling {
       elbs:        Option[Seq[Token[ResourceRef[`AWS::ElasticLoadBalancing::LoadBalancer`]]]] = None
     )(implicit vpc: `AWS::EC2::VPC`) = {
 
-      val resourceName = baseName + "LaunchConfig"
       val asgName = baseName + "AutoScale"
 
       val launchConfigSGR @ SecurityGroupRoutable(aLaunchConfig, _, _) =
@@ -514,7 +513,7 @@ trait Gateway {
     val gName = "InternetGateway"
     val gateway = `AWS::EC2::InternetGateway`(
       gName,
-      Tags = AmazonTag.fromName(gName)
+      Tags = AmazonTag.stackName()
     )
 
     val attName = "GatewayToInternet"
@@ -531,10 +530,12 @@ trait Gateway {
 trait VPC extends Outputs {
   implicit class RichVPC(vpc: `AWS::EC2::VPC`)
 
-  def withVpc(cidrBlock: Token[CidrBlock])(f: (`AWS::EC2::VPC`) => Template): Template = {
-    val vpcName = "VPC"
+  def withVpc(cidrBlock: Token[CidrBlock], vpcName: Option[String] = None)(f: (`AWS::EC2::VPC`) => Template): Template = {
     val vpc = `AWS::EC2::VPC`(
-      vpcName,
+      vpcName match {
+        case Some(n) => n
+        case None => "VPC"
+      },
       CidrBlock = cidrBlock,
       Tags = AmazonTag.fromName(vpcName),
       EnableDnsSupport = true,

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/RDS_UT.scala
@@ -348,13 +348,7 @@ class RDS_UT extends FunSpec with Matchers {
             "StorageType" -> JsString("gp2"),
             "Tags" -> JsArray(JsObject(
               "Key" -> JsString("Name"),
-              "Value" -> JsObject("Fn::Join" -> JsArray(
-                JsString("-"),
-                JsArray(
-                  JsString(dbName),
-                  JsObject("Ref" -> JsString("AWS::StackName"))
-                )
-              ))
+              "Value" -> JsObject("Fn::Sub" -> JsString(s"$${AWS::StackName}-${dbName}"))
             ))
           )
         )


### PR DESCRIPTION
Since the "name" in the template is typically a constant, and the stack name is what varies, put stack name first.  Also tweaked a few other things, such as removing "VPC" from the VPC name tag by default.  Pass in a name if you have more than one VPC per stack.