### PR TITLE
Fix PolicyType in ScalingPolicy

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApplicationAutoScaling.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/ApplicationAutoScaling.scala
@@ -113,5 +113,15 @@ case class `AWS::ApplicationAutoScaling::ScalingPolicy`(name: String,
 
 object `AWS::ApplicationAutoScaling::ScalingPolicy` extends DefaultJsonProtocol {
   private type T = `AWS::ApplicationAutoScaling::ScalingPolicy`
-  implicit val format: JsonFormat[T] = jsonFormat10(apply)
+  implicit val format: JsonFormat[T] = jsonFormat(apply,
+  "name",
+  "PolicyName",
+  "PolicyType",
+  "ResourceId",
+  "ScalableDimension",
+  "ScalingTargetId",
+  "ServiceNamespace",
+  "StepScalingPolicyConfiguration",
+  "Condition",
+  "DependsOn")
 }

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ApplicationAutoScaling_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/ApplicationAutoScaling_UT.scala
@@ -1,0 +1,58 @@
+package com.monsanto.arch.cloudformation.model.resource
+
+import com.monsanto.arch.cloudformation.model.JsonWritingMatcher
+import com.monsanto.arch.cloudformation.model.resource.`AWS::CloudWatch::Alarm::Namespace`.CustomNamespace
+import org.scalatest.{FunSpec, Matchers}
+
+class ApplicationAutoScaling_UT extends FunSpec with Matchers with JsonWritingMatcher {
+
+  it("should generate scalable target policy document") {
+    val scalableTarget = `AWS::ApplicationAutoScaling::ScalableTarget`(
+      name = "myScalableTarget",
+      MaxCapacity = 100,
+      MinCapacity = 1,
+      ResourceId = "myResourceId",
+      RoleARN = "myRoleArn",
+      ScalableDimension = "myScalableDimension",
+      ServiceNamespace = CustomNamespace("custom-resource"))
+
+    val resource: Resource[`AWS::ApplicationAutoScaling::ScalableTarget`] = scalableTarget
+
+    resource shouldMatch
+      """
+        |{
+        |  "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+        |  "Properties": {
+        |    "MaxCapacity": 100,
+        |    "MinCapacity": 1,
+        |    "ResourceId": "myResourceId",
+        |    "RoleARN": "myRoleArn",
+        |    "ScalableDimension": "myScalableDimension",
+        |    "ServiceNamespace": "custom-resource"
+        |  }
+        |}
+      """.stripMargin
+  }
+
+  it("should generate scaling policy document") {
+    val scalingPolicy = `AWS::ApplicationAutoScaling::ScalingPolicy`(
+      name = "myScalingPolicy",
+      PolicyName = "myPolicyName",
+      ScalingType = ApplicationAutoScaling.ScalingType.StepScaling,
+      ScalingTargetId = Some("myScalingTargetId"))
+
+    val resource: Resource[`AWS::ApplicationAutoScaling::ScalingPolicy`] = scalingPolicy
+
+    resource shouldMatch
+      """
+        |{
+        |  "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+        |  "Properties": {
+        |    "PolicyName": "myPolicyName",
+        |    "PolicyType": "StepScaling",
+        |    "ScalingTargetId": "myScalingTargetId"
+        |  }
+        |}
+      """.stripMargin
+  }
+}


### PR DESCRIPTION
Non-breaking change to fix ScalingPolicy to have correct name for PolicyType field. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html#cfn-applicationautoscaling-scalingpolicy-policytype

This PR is paired with the breaking equivalent in PR #259. The expectation is that only one PR is accepted, or this PR is accepted as a bugfix version update and #259 is accepted as a major version update.