### PR TITLE
added billing mode

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDB.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDB.scala
@@ -13,6 +13,7 @@ import scala.language.implicitConversions
 case class `AWS::DynamoDB::Table`(
                                    name: String,
                                    AttributeDefinitions: Seq[AttributeDefinition],
+                                   BillingMode: Option[BillingMode],
                                    GlobalSecondaryIndexes: Seq[GlobalSecondaryIndex],
                                    KeySchema: Seq[KeySchema],
                                    LocalSecondaryIndexes: Seq[LocalSecondaryIndex],
@@ -40,7 +41,7 @@ case class `AWS::DynamoDB::Table`(
 }
 
 object `AWS::DynamoDB::Table` {
-  implicit val format: JsonFormat[`AWS::DynamoDB::Table`] = jsonFormat12(`AWS::DynamoDB::Table`.apply)
+  implicit val format: JsonFormat[`AWS::DynamoDB::Table`] = jsonFormat13(`AWS::DynamoDB::Table`.apply)
 }
 
 sealed abstract class StreamViewType(val name : String)

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Resource.scala
@@ -63,3 +63,11 @@ object DeletionPolicy extends DefaultJsonProtocol {
   val values = Seq(Delete, Retain, Snapshot)
   implicit val format: JsonFormat[DeletionPolicy] = new EnumFormat[DeletionPolicy](values)
 }
+
+sealed trait BillingMode
+object BillingMode extends DefaultJsonProtocol {
+  case object PROVISIONED extends BillingMode
+  case object PAY_PER_REQUEST extends BillingMode
+  val values = Seq(PROVISIONED, PAY_PER_REQUEST)
+  implicit val format: JsonFormat[BillingMode] = new EnumFormat[BillingMode](values)
+}

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDBSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDBSpec.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model.JsonWritingMatcher
+import com.monsanto.arch.cloudformation.model.resource.BillingMode.PROVISIONED
 import com.monsanto.arch.cloudformation.model.resource.DeletionPolicy.Retain
 import org.scalatest.{FunSpec, Matchers}
 import spray.json.{JsString, JsonWriter}
@@ -15,6 +16,7 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
       AttributeDefinitions = Seq(
         "name" -> StringAttributeType
       ),
+      BillingMode = Some(PROVISIONED),
       GlobalSecondaryIndexes = Seq(GlobalSecondaryIndex(
         IndexName = "globalIndex1",
         KeySchema = Seq(
@@ -77,6 +79,7 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
         |     "AttributeName":"name",
         |     "AttributeType":"S"
         |   }],
+        | "BillingMode":"PROVISIONED",
         | "GlobalSecondaryIndexes":[
         |   {
         |     "IndexName":"globalIndex1",


### PR DESCRIPTION
Added option for specifying the billing mode which in turn provides on-demand read-write capacity

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-billingmode

read more in this blog https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/