### PR TITLE
BillingMode PAY_PER_REQUEST validation also for GlobalSecondaryIndexes

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDB.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDB.scala
@@ -31,6 +31,7 @@ case class `AWS::DynamoDB::Table`(
                                  ) extends Resource[`AWS::DynamoDB::Table`] with HasArn {
   require((BillingMode.isEmpty || BillingMode.contains(PROVISIONED)) ^ ProvisionedThroughput.isEmpty, "Provisioned Throughput is mandatory if Billing mode is NOT provided or PROVISIONED. Also You cannot specify provisioned throughput for PAY_PER_REQUEST billing mode")
   require(BillingMode.contains(PAY_PER_REQUEST) ^ ProvisionedThroughput.nonEmpty, "Provisioned Throughput is mandatory if Billing mode is NOT provided or PROVISIONED. Also You cannot specify provisioned throughput for PAY_PER_REQUEST billing mode")
+  require(BillingMode.contains(PAY_PER_REQUEST) ^ GlobalSecondaryIndexes.exists(_.ProvisionedThroughput.isDefined), "Provisioned Throughput is mandatory if Billing mode is NOT provided or PROVISIONED. Also You cannot specify provisioned throughput for PAY_PER_REQUEST billing mode")
 
   override def arn = aws"arn:aws:dynamodb:${`AWS::Region`}:${`AWS::AccountId`}:table/${ResourceRef(this)}"
 
@@ -186,7 +187,7 @@ case class GlobalSecondaryIndex (
                                   IndexName: String,
                                   KeySchema: Seq[KeySchema],
                                   Projection: Projection,
-                                  ProvisionedThroughput: ProvisionedThroughput
+                                  ProvisionedThroughput: Option[ProvisionedThroughput] = None
                                 ) extends DynamoIndex
 
 object GlobalSecondaryIndex {

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDBSpec.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/DynamoDBSpec.scala
@@ -232,10 +232,6 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
           "gKey1" -> HashKeyType
         ),
         Projection = AllProjection,
-        ProvisionedThroughput = ProvisionedThroughput(
-          ReadCapacityUnits = 1,
-          WriteCapacityUnits = 1
-        )
       )),
       KeySchema = Seq(
         "key1" -> RangeKeyType
@@ -291,10 +287,6 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
         |       }],
         |     "Projection":{
         |       "ProjectionType":"ALL"
-        |     },
-        |     "ProvisionedThroughput":{
-        |       "ReadCapacityUnits":1,
-        |       "WriteCapacityUnits":1
         |     }
         |   }],
         |  "KeySchema":[
@@ -344,6 +336,44 @@ class DynamoDBSpec extends FunSpec with Matchers with JsonWritingMatcher {
           ReadCapacityUnits = 1,
           WriteCapacityUnits = 1
         ),
+        TableName = Some("Table1"),
+        DeletionPolicy = Some(Retain),
+        DependsOn = Some(Seq("myothertable")),
+        TimeToLiveSpecification = Some(TimeToLiveSpecification(AttributeName = "ttl", Enabled = true))
+      )
+
+    }
+    assert(ex.getMessage === "requirement failed: Provisioned Throughput is mandatory if Billing mode is NOT provided or PROVISIONED. Also You cannot specify provisioned throughput for PAY_PER_REQUEST billing mode")
+  }
+  it("should NOT generate policy document if Billing Mode is PAY_PER_REQUEST and has Provisioned Throughput defined in GlobalSecondaryIndexes") {
+    val ex = intercept[IllegalArgumentException] {
+      val dynamoDbTable = `AWS::DynamoDB::Table`(
+        name = "mytable",
+        AttributeDefinitions = Seq(
+          "name" -> StringAttributeType
+        ),
+        BillingMode = Some(PAY_PER_REQUEST),
+        GlobalSecondaryIndexes = Seq(GlobalSecondaryIndex(
+          IndexName = "globalIndex1",
+          KeySchema = Seq(
+            "gKey1" -> HashKeyType
+          ),
+          Projection = AllProjection,
+          ProvisionedThroughput = ProvisionedThroughput(
+            ReadCapacityUnits = 1,
+            WriteCapacityUnits = 1
+          )
+        )),
+        KeySchema = Seq(
+          "key1" -> RangeKeyType
+        ),
+        LocalSecondaryIndexes = Seq(LocalSecondaryIndex(
+          IndexName = "localIndex1",
+          KeySchema = Seq(
+            "key2" -> HashKeyType
+          ),
+          Projection = IncludeProjection(Seq("test1"))
+        )),
         TableName = Some("Table1"),
         DeletionPolicy = Some(Retain),
         DependsOn = Some(Seq("myothertable")),


### PR DESCRIPTION
Extended on [this PR](https://github.com/MonsantoCo/cloudformation-template-generator/pull/266)
to get the BillingMode PAY_PER_REQUEST even better supported.
Implemented the check (and tests) that ProvisionedThoughput is also not allowed in the GlobalSecondaryIndexes 
when PAY_PER_REQUEST is enabled.