### PR TITLE
Kinesis Firehose S3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.9.2]
+  - Added Kinesis Firehose Delivery Stream S3 support
+  - Added Kinesis Stream Encryption support
+
 ## [3.9.1] - 2018-06-08
   - Added Node 8.10 as a lambda runtime option (see [#254](https://github.com/MonsantoCo/cloudformation-template-generator/pull/254))
   - Added the tags field to Lambda Functions (see [#254](https://github.com/MonsantoCo/cloudformation-template-generator/pull/254))

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ describe("Template Lookup") {
 - AWS::IAM::Role
 - AWS::IAM::User
 - AWS::Kinesis::Stream
+- AWS::KinesisFirehose::DeliveryStream
 - AWS::KMS::Alias
 - AWS::KMS::Key
 - AWS::Lambda::Alias

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis.scala
@@ -210,6 +210,7 @@ object `AWS::KinesisFirehose::DeliveryStream` extends DefaultJsonProtocol{
 
   def s3(name: String,
     ExtendedS3DestinationConfiguration: ExtendedS3DestinationConfiguration,
+    KinesisStreamSourceConfiguration :Option[KinesisStreamSourceConfiguration] = None,
     DeliveryStreamName: Option[String] = None,
     DeliveryStreamType: Option[DeliveryStreamType] = None,
     DependsOn: Option[Seq[String]] = None,
@@ -219,6 +220,7 @@ object `AWS::KinesisFirehose::DeliveryStream` extends DefaultJsonProtocol{
       DeliveryStreamName,
       DeliveryStreamType,
       Some(ExtendedS3DestinationConfiguration),
+      KinesisStreamSourceConfiguration = KinesisStreamSourceConfiguration,
       DependsOn = DependsOn,
       Condition = Condition
     )

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis.scala
@@ -1,7 +1,16 @@
 package com.monsanto.arch.cloudformation.model.resource
 
-import com.monsanto.arch.cloudformation.model.{ConditionRef, Token, `Fn::GetAtt`}
+import com.monsanto.arch.cloudformation.model.{ConditionRef, EnumFormat, Token, `Fn::GetAtt`}
 import spray.json._
+
+case class StreamEncryption(
+  KeyId: Token[String],
+  EncryptionType: String = "KMS"
+)
+
+object StreamEncryption extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[StreamEncryption] = jsonFormat2(StreamEncryption.apply)
+}
 
 case class `AWS::Kinesis::Stream`(
   name: String,
@@ -10,12 +19,209 @@ case class `AWS::Kinesis::Stream`(
   RetentionPeriodHours: Option[Token[Int]] = None,
   Tags: Option[Seq[AmazonTag]] = None,
   override val DependsOn: Option[Seq[String]] = None,
-  override val Condition: Option[ConditionRef] = None
+  override val Condition: Option[ConditionRef] = None,
+  StreamEncryption: Option[StreamEncryption] = None
 ) extends Resource[`AWS::Kinesis::Stream`] with HasArn {
   override def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
   override def arn = `Fn::GetAtt`(Seq(name, "Arn"))
 }
 
 object `AWS::Kinesis::Stream` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::Kinesis::Stream`] = jsonFormat7(`AWS::Kinesis::Stream`.apply)
+  implicit val format: JsonFormat[`AWS::Kinesis::Stream`] = jsonFormat8(`AWS::Kinesis::Stream`.apply)
+}
+
+case class BufferingHints(
+  IntervalInSeconds: Option[Int],
+  SizeInMBs: Option[Int]
+)
+
+case object BufferingHints extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[BufferingHints] = jsonFormat2(BufferingHints.apply)
+}
+
+case class CloudWatchLoggingOptions(
+  Enabled: Option[Boolean],
+  LogGroupName: Option[Token[String]],
+  LogStreamName: Option[Token[String]]
+)
+
+case object CloudWatchLoggingOptions extends DefaultJsonProtocol {
+  def disabled = CloudWatchLoggingOptions(Some(false), None, None)
+
+  def enabled(LogGroupName: Token[String], LogStreamName: Token[String]) =
+    CloudWatchLoggingOptions(Some(true), Some(LogGroupName), Some(LogStreamName))
+
+  implicit val format: JsonFormat[CloudWatchLoggingOptions] = jsonFormat3(CloudWatchLoggingOptions.apply)
+}
+
+case class KMSEncryptionConfig(
+  AWSKMSKeyARN: Token[String]
+)
+
+object KMSEncryptionConfig extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[KMSEncryptionConfig] = jsonFormat1(KMSEncryptionConfig.apply)
+}
+
+
+case class EncryptionConfiguration(
+  KMSEncryptionConfig: Option[KMSEncryptionConfig],
+  NoEncryptionConfig: Option[String]
+)
+
+object EncryptionConfiguration extends DefaultJsonProtocol {
+  def withKMS(config:KMSEncryptionConfig) = new EncryptionConfiguration(Some(config),None)
+  def noEncryption = new EncryptionConfiguration(None,Some("NoEncryption"))
+  implicit val format: JsonFormat[EncryptionConfiguration] = jsonFormat2(EncryptionConfiguration.apply)
+}
+
+case class ProcessorParameter(
+  ParameterName: String,
+  ParameterValue: Token[String])
+
+object ProcessorParameter extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[ProcessorParameter] = jsonFormat2(ProcessorParameter.apply)
+}
+
+case class Processor(
+  Parameters: Seq[ProcessorParameter],
+  Type: String = "Lambda"
+)
+object Processor extends DefaultJsonProtocol{
+  implicit val format: JsonFormat[Processor] = jsonFormat2(Processor.apply)
+
+}
+
+case class ProcessingConfiguration(
+  Enabled: Option[Boolean],
+  Processors: Option[Seq[Processor]]
+)
+
+object ProcessingConfiguration extends DefaultJsonProtocol {
+  def disabled = ProcessingConfiguration(Some(false), None)
+
+  def enabled(processors: Seq[Processor]) = ProcessingConfiguration(Some(true), Some(processors))
+
+  implicit val format: JsonFormat[ProcessingConfiguration] = jsonFormat2(ProcessingConfiguration.apply)
+}
+
+case class S3DestinationConfiguration(
+  BucketARN: String,
+  BufferingHints: BufferingHints,
+  CloudWatchLoggingOptions: CloudWatchLoggingOptions,
+  CompressionFormat: String,
+  EncryptionConfiguration: EncryptionConfiguration,
+  Prefix: String,
+  RoleARN: String
+)
+
+object S3DestinationConfiguration extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[S3DestinationConfiguration] = jsonFormat7(S3DestinationConfiguration.apply)
+}
+
+sealed trait CompressionForma
+
+object CompressionFormat {
+
+  case object UNCOMPRESSED extends CompressionForma
+
+  case object GZIP extends CompressionForma
+
+  case object ZIP extends CompressionForma
+
+  case object Snappy extends CompressionForma
+
+  val values = List(UNCOMPRESSED, GZIP, ZIP, Snappy)
+  implicit val format: JsonFormat[CompressionFormat] = new EnumFormat[CompressionFormat](values)
+}
+
+case class ExtendedS3DestinationConfiguration(
+  BucketARN: Token[String],
+  RoleARN: Token[String],
+  BufferingHints: Option[BufferingHints] = None,
+  CloudWatchLoggingOptions: Option[CloudWatchLoggingOptions] = None,
+  CompressionFormat: Option[CompressionFormat] = None,
+  EncryptionConfiguration: Option[EncryptionConfiguration] = None,
+  Prefix: Option[String] = None,
+  ProcessingConfiguration: Option[ProcessingConfiguration] = None,
+  S3BackupConfiguration: Option[S3DestinationConfiguration] = None,
+  S3BackupMode: Option[String] = None
+)
+
+object ExtendedS3DestinationConfiguration extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[ExtendedS3DestinationConfiguration] = jsonFormat10(ExtendedS3DestinationConfiguration.apply)
+}
+
+case class ElasticsearchDestinationConfiguration(CloudWatchLoggingOptions: CloudWatchLoggingOptions,
+  BufferingHints: Option[BufferingHints])
+object ElasticsearchDestinationConfiguration extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[ElasticsearchDestinationConfiguration] = jsonFormat2(ElasticsearchDestinationConfiguration.apply)
+}
+
+
+case class KinesisStreamSourceConfiguration(
+  KinesisStreamARN : Token[String],
+  RoleARN : Token[String]
+)
+object KinesisStreamSourceConfiguration extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[KinesisStreamSourceConfiguration] = jsonFormat2(KinesisStreamSourceConfiguration.apply)
+}
+
+case class RedshiftDestinationConfiguration(CloudWatchLoggingOptions: CloudWatchLoggingOptions)
+object RedshiftDestinationConfiguration extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[RedshiftDestinationConfiguration] = jsonFormat1(RedshiftDestinationConfiguration.apply)
+}
+
+case class SplunkDestinationConfiguration(CloudWatchLoggingOptions: CloudWatchLoggingOptions)
+object SplunkDestinationConfiguration extends DefaultJsonProtocol {
+  implicit val format: JsonFormat[SplunkDestinationConfiguration] = jsonFormat1(SplunkDestinationConfiguration.apply)
+}
+
+sealed trait DeliveryStreamType
+
+object DeliveryStreamType extends DefaultJsonProtocol {
+
+  case object DirectPut extends DeliveryStreamType
+
+  case object KinesisStreamAsSource extends DeliveryStreamType
+
+  val values = List(DirectPut, KinesisStreamAsSource)
+  implicit val format: JsonFormat[DeliveryStreamType] = new EnumFormat[DeliveryStreamType](values)
+}
+
+
+case class `AWS::KinesisFirehose::DeliveryStream`(
+  name: String,
+  DeliveryStreamName: Option[String] = None,
+  DeliveryStreamType: Option[DeliveryStreamType] = None,
+  ExtendedS3DestinationConfiguration: Option[ExtendedS3DestinationConfiguration] = None,
+  ElasticsearchDestinationConfiguration: Option[ElasticsearchDestinationConfiguration] = None,
+  KinesisStreamSourceConfiguration: Option[KinesisStreamSourceConfiguration] = None,
+  RedshiftDestinationConfiguration: Option[RedshiftDestinationConfiguration] = None,
+  SplunkDestinationConfiguration: Option[SplunkDestinationConfiguration] = None,
+  override val DependsOn: Option[Seq[String]] = None,
+  override val Condition: Option[ConditionRef] = None
+) extends Resource[`AWS::KinesisFirehose::DeliveryStream`] with HasArn {
+  override def when(newCondition: Option[ConditionRef] = Condition) = copy(Condition = newCondition)
+
+  override def arn = `Fn::GetAtt`(Seq(name, "Arn"))
+}
+
+object `AWS::KinesisFirehose::DeliveryStream` extends DefaultJsonProtocol{
+
+  def s3(name: String,
+    ExtendedS3DestinationConfiguration: ExtendedS3DestinationConfiguration,
+    DeliveryStreamName: Option[String] = None,
+    DeliveryStreamType: Option[DeliveryStreamType] = None,
+    DependsOn: Option[Seq[String]] = None,
+    Condition: Option[ConditionRef] = None) =
+    new `AWS::KinesisFirehose::DeliveryStream`(
+      name,
+      DeliveryStreamName,
+      DeliveryStreamType,
+      Some(ExtendedS3DestinationConfiguration),
+      DependsOn = DependsOn,
+      Condition = Condition
+    )
+
+  implicit val format: JsonFormat[`AWS::KinesisFirehose::DeliveryStream`] = jsonFormat10(`AWS::KinesisFirehose::DeliveryStream`.apply)
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis.scala
@@ -118,17 +118,17 @@ object S3DestinationConfiguration extends DefaultJsonProtocol {
   implicit val format: JsonFormat[S3DestinationConfiguration] = jsonFormat7(S3DestinationConfiguration.apply)
 }
 
-sealed trait CompressionForma
+sealed trait CompressionFormat
 
 object CompressionFormat {
 
-  case object UNCOMPRESSED extends CompressionForma
+  case object UNCOMPRESSED extends CompressionFormat
 
-  case object GZIP extends CompressionForma
+  case object GZIP extends CompressionFormat
 
-  case object ZIP extends CompressionForma
+  case object ZIP extends CompressionFormat
 
-  case object Snappy extends CompressionForma
+  case object Snappy extends CompressionFormat
 
   val values = List(UNCOMPRESSED, GZIP, ZIP, Snappy)
   implicit val format: JsonFormat[CompressionFormat] = new EnumFormat[CompressionFormat](values)

--- a/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis_UT.scala
+++ b/src/test/scala/com/monsanto/arch/cloudformation/model/resource/Kinesis_UT.scala
@@ -1,6 +1,7 @@
 package com.monsanto.arch.cloudformation.model.resource
 
 import com.monsanto.arch.cloudformation.model._
+import com.monsanto.arch.cloudformation.model.resource.S3VersioningStatus.Enabled
 import org.scalatest.{FunSpec, Matchers}
 import spray.json._
 
@@ -32,6 +33,60 @@ class Kinesis_UT extends FunSpec with Matchers {
       stream.ShardCount shouldEqual IntToken(shardCount)
       stream.RetentionPeriodHours foreach (_ shouldEqual IntToken(retentionPeriodHours))
       stream.Tags.get shouldEqual Seq(AmazonTag("Name", streamName))
+    }
+  }
+
+  describe("FirehoseDeliveryStream") {
+    it("should create a plausible S3 firehose stream config") {
+      val bucket = `AWS::S3::Bucket`("s3bucket", None,
+        VersioningConfiguration = Some(S3VersioningConfiguration(Enabled)))
+      val deliveryRole = `AWS::IAM::Role`("deliveryRole",
+        PolicyDocument(Seq(PolicyStatement(
+          "Allow",
+          Some(DefinedPrincipal(Map("Service" -> Token.fromString("firehose.amazonaws.com")))),
+          Seq("sts:AssumeRole"),
+          Sid = Some(" "),
+          Condition = Some(Map("StringEquals" -> Map("sts:ExternalId" -> SimplePolicyConditionValue("AWS::AccountId"))))
+        ))))
+      val policy = `AWS::IAM::Policy`("deliveryPolicy",
+        PolicyDocument(Seq(
+          PolicyStatement("Allow",
+            Action = Seq("s3:AbortMultipartUpload",
+              "s3:GetBucketLocation",
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:ListBucketMultipartUploads",
+              "s3:PutObject"
+            ),
+            Resource = Some(Seq(`Fn::Join`("", Seq(s"arn:aws:s3:::", ResourceRef(bucket))),
+              `Fn::Join`("", Seq(s"arn:aws:s3:::", ResourceRef(bucket), "/*"))))
+
+          ))
+        ), "firehose_delivery_policy",
+        Roles = Some(Seq(ResourceRef(deliveryRole))))
+
+      val stream = `AWS::KinesisFirehose::DeliveryStream`.s3(
+        "deliveryStream",
+        ExtendedS3DestinationConfiguration(`Fn::Join`("", Seq(s"arn:aws:s3:::", ResourceRef(bucket))),
+          ResourceRef(deliveryRole),
+          Some(BufferingHints(Some(60), Some(50))), None,
+          Some(CompressionFormat.UNCOMPRESSED), None, Some("firehose/"),
+          Some(ProcessingConfiguration.enabled(
+            Seq(Processor(
+              Seq(ProcessorParameter("LambdaArn",
+                Token.fromFunction(`Fn::GetAtt`(Seq("myLambda","Arn")))))
+            ))))
+        ), DependsOn = Some(Seq(policy.name)))
+      val tJson = Template(Resources = Seq(stream, policy,deliveryRole,bucket))
+
+      val deliveryJson = tJson.toJson.asJsObject.fields("Resources")
+        .asJsObject.fields("deliveryStream").asJsObject()
+        deliveryJson.fields("DependsOn") shouldBe JsArray(JsString("deliveryPolicy"))
+
+      deliveryJson.fields("Properties").asJsObject().fields("ExtendedS3DestinationConfiguration")
+        .asJsObject.fields("BufferingHints") shouldBe JsObject(
+        Map("IntervalInSeconds" -> JsNumber(60), "SizeInMBs" -> JsNumber(50))
+      )
     }
   }
 }


### PR DESCRIPTION
The Kinesis Firehose CF types are more than complicated enough that I don't want to do proper additions of all possible types. I added placeholders for Non-S3 versions, to be added as needed.

(Note: I'd not release a version of CFTG just yet. Clean the deck of PRs first.)