### PR TITLE
Added UNSAFEFunctionCallToken to represent cloudformation functions t…

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AmazonFunctionCall.scala
@@ -260,6 +260,7 @@ object Token extends DefaultJsonProtocol {
         case s: UNSAFEToken[_]             => s.value.toJson
           // its OK to erase the return type of AmazonFunctionCalls b/c they are only used at compile time for checking
           // not for de/serialization logic or JSON representation
+        case f: UNSAFEFunctionCallToken[_]      => implicitly[JsonWriter[AmazonFunctionCall[_]]].write(f.call)
         case f: FunctionCallToken[_]       => implicitly[JsonWriter[AmazonFunctionCall[_]]].write(f.call)
         case f: FunctionCallSeqToken[_]    => implicitly[JsonWriter[AmazonFunctionCall[_]]].write(f.call)
         case p: PseudoParameterRef         => p.toJson
@@ -295,6 +296,8 @@ case class FunctionCallSeqToken[R](call: AmazonFunctionCall[Seq[R]]) extends Tok
 
 @deprecated("use ParameterRef or ResourceRef instead", "Feb 20 2015")
 case class UNSAFEToken[R](value: String) extends Token[R]
+
+case class UNSAFEFunctionCallToken[R](call: AmazonFunctionCall[String]) extends Token[R]
 
 sealed abstract class PseudoParameterRef(val name: String) extends Token[String]
 object PseudoParameterRef extends DefaultJsonProtocol {


### PR DESCRIPTION
…hat return strings which are assumed to conform to be the proper string representation of a stricter type, such as a CIDR block.

The motivation for this change is that using `Fn::GetAtt` to get the results of a custom resource is essentially a `Token[String]`, which cannot be used with more specific type requirements, such as a `Token[CidrBlock]` needed for a VPC or Subnet.

This change allows for a custom resource to output a value as a string, which can be retrieved with a `Fn::GetAtt`, wrapped in `UNSAFEFunctionCallToken`, and used as a parameter for a another resource.  This change is backwards compatable and will not break any existing cftg code.