### PR TITLE
Added tags to IAM roles

### DIFF
--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/IAM.scala
@@ -126,6 +126,7 @@ case class `AWS::IAM::Role`(
   Policies:                 Option[Seq[Policy]] = None,
   PermissionsBoundary:      Option[Token[String]] = None,
   RoleName:                 Option[Token[String]] = None,
+  Tags:                     Option[Seq[AmazonTag]] = None,
   override val DependsOn: Option[Seq[String]] = None,
   override val Condition: Option[ConditionRef] = None
   ) extends Resource[`AWS::IAM::Role`] with HasArn {
@@ -135,7 +136,7 @@ case class `AWS::IAM::Role`(
   override def arn = `Fn::GetAtt`(Seq(name, "Arn"))
 }
 object `AWS::IAM::Role` extends DefaultJsonProtocol {
-  implicit val format: JsonFormat[`AWS::IAM::Role`] = jsonFormat9(`AWS::IAM::Role`.apply)
+  implicit val format: JsonFormat[`AWS::IAM::Role`] = jsonFormat10(`AWS::IAM::Role`.apply)
 }
 
 sealed trait PolicyConditionValue


### PR DESCRIPTION
Added tagging for IAM roles.  The field is optional and `None` by default, so it should not break any existing code.