### PR TITLE
Upgrade to Scala 2.13: cross builds for 2.11 and 2.12, all tests pass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ startYear := Some(2014)
 
 // scala versions and options
 
-scalaVersion := "2.12.13"
-crossScalaVersions := Seq("2.11.12", "2.12.13")
+scalaVersion := "2.13.6"
+crossScalaVersions := Seq("2.11.12", "2.12.13", "2.13.6")
 releaseCrossBuild := true
 
 // These options will be used for *all* versions.
@@ -39,7 +39,7 @@ javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
 
 libraryDependencies ++= Seq (
   // -- testing --
-   "org.scalatest"  %% "scalatest"     % "3.0.4"  % Test
+   "org.scalatest"  %% "scalatest"     % "3.0.8"  % Test
   // -- json --
   ,"io.spray"       %%  "spray-json"   % "1.3.6"
   // -- reflection --

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/AwsStringInterpolation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/AwsStringInterpolation.scala
@@ -8,16 +8,13 @@ object AwsStringInterpolation {
   /**
     * Takes a sequence of objects and zips them together such that
     */
-  case class Zipper[A](parts: Seq[A]*) extends Traversable[A] {
-    override def foreach[U](f: (A) => U): Unit = {
-      val i = parts.map(_.iterator)
-      while (i.exists(_.hasNext))
-        i.foreach { v =>
-          if (v.hasNext) {
-            f(v.next)
-          }
-        }
-    }
+  case class Zipper[A](parts: Seq[A]*) extends Iterable[A] {
+
+    override def iterator: Iterator[A] =
+      if (parts.isEmpty)
+        Seq[A]().iterator
+      else  
+        parts.iterator.flatMap(_.headOption) ++ Zipper(parts.flatMap(p => p.headOption.map(_ => p.tail)): _*).iterator
   }
 
   def apply(sc: StringContext, tokens: Seq[Token[String]]): Token[String] = {

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/JsonUtils.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/JsonUtils.scala
@@ -19,4 +19,22 @@ object JsonWritable {
   }
 
   implicit def wrap[T: JsonWriter](thing: T) = JsonWritable(thing)
+
+  // wrap[T: JsonWriter] no longer works in Scala 2.13 for basic types in pairs because of changes to the implicit resolution
+  // (it does work though for case classes where the format is defined as a JsonWriter on the companion object).
+  // Added the following implicits as a workaround for basic types, although not sure if JsonWritable is a good idea in the long run.
+  
+  implicit def wrapString(thing: String)(implicit fmt: JsonWriter[String]) = wrap(thing)
+
+  implicit def wrapInt(thing: Int)(implicit fmt: JsonWriter[Int]) = wrap(thing)
+
+  implicit def wrapLong(thing: Long)(implicit fmt: JsonWriter[Long]) = wrap(thing)
+
+  implicit def wrapFloat(thing: Float)(implicit fmt: JsonWriter[Float]) = wrap(thing)
+
+  implicit def wrapDouble(thing: Double)(implicit fmt: JsonWriter[Double]) = wrap(thing)
+
+  implicit def wrapBigDecimal(thing: BigDecimal)(implicit fmt: JsonWriter[BigDecimal]) = wrap(thing)
+
+  implicit def wrapBoolean(thing: Boolean)(implicit fmt: JsonWriter[Boolean]) = wrap(thing)
 }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/Template.scala
@@ -109,7 +109,7 @@ object Template extends DefaultJsonProtocol {
       if(p.Mappings.nonEmpty) fields ++= productElement2Field[Option[Seq[Mapping[_]]]]("Mappings", p, 3)
       fields ++= productElement2Field[Seq[Resource[_]]]("Resources", p, 4)
       if(p.Outputs.nonEmpty) fields ++= productElement2Field[Option[Seq[Output[_]]]]("Outputs", p, 6)
-      JsObject(ListMap(fields: _*))
+      JsObject(ListMap(fields.toSeq: _*))
     }
   }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/CloudFormation.scala
@@ -86,7 +86,7 @@ object `AWS::CloudFormation::CustomResource` extends spray.json.DefaultJsonProto
     override def write(obj: `AWS::CloudFormation::CustomResource`): JsValue = {
       val st = ("ServiceToken" -> obj.ServiceToken.toJson)
       obj.Parameters match {
-        case Some(p) => JsObject(p.mapValues(v => v.toJson) + st)
+        case Some(p) => JsObject(p.mapValues(v => v.toJson).toMap + st)
         case None => JsObject(st)
       }
     }

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EC2.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/EC2.scala
@@ -335,7 +335,7 @@ object `AWS::EC2::Route` extends DefaultJsonProtocol {
           "VpcPeeringConnectionId" -> writeField(p.VpcPeeringConnectionId),
           "Condition"              -> writeField(p.Condition),
           "DependsOn"              -> writeField(p.DependsOn)
-        ).filter(_._2.isDefined).mapValues(_.get)
+        ).filter(_._2.isDefined).mapValues(_.get).toMap
       )
     }
 
@@ -656,7 +656,7 @@ object `AWS::EC2::VPCGatewayAttachment` extends DefaultJsonProtocol {
           "VpnGatewayId"           -> writeField(p.VpnGatewayId),
           "InternetGatewayId"      -> writeField(p.InternetGatewayId),
           "Condition"              -> writeField(p.Condition)
-        ).filter(_._2.isDefined).mapValues(_.get)
+        ).filter(_._2.isDefined).mapValues(_.get).toMap
       )
     }
 

--- a/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Route53.scala
+++ b/src/main/scala/com/monsanto/arch/cloudformation/model/resource/Route53.scala
@@ -67,7 +67,7 @@ object `AWS::Route53::RecordSet` extends DefaultJsonProtocol {
   implicit val format: JsonFormat[`AWS::Route53::RecordSet`] = new JsonFormat[`AWS::Route53::RecordSet`]{
     def write(p: `AWS::Route53::RecordSet`) = {
       JsObject(
-        Route53RecordSetBaseFields.writeCoreFields(p).filter(_._2.isDefined).mapValues(_.get)
+        Route53RecordSetBaseFields.writeCoreFields(p).filter(_._2.isDefined).mapValues(_.get).toMap
       )
     }
 
@@ -142,7 +142,7 @@ object `Custom::RemoteRoute53RecordSet` {
         (Route53RecordSetBaseFields.writeCoreFields(p)
           + ("ServiceToken"            -> writeField(p.ServiceToken))
           + ("DestinationRole"            -> writeField(p.DestinationRole))
-          ).filter(_._2.isDefined).mapValues(_.get)
+          ).filter(_._2.isDefined).mapValues(_.get).toMap
       )
     }
 


### PR DESCRIPTION
Hi, I have upgraded cloudformation-template-generator to Scala 2.13. It still cross builds for 2.11 and 2.12. Changes:

- The majority of changes are related to the MapView change in the collections API
- ScalaTest patch version upgrade (the old one doesn't have 2.13 artifacts) 
- A workaround has been added for the JsonWritable implicit conversion, which is required because of implicit resolution changes in 2.13 (see comment)
- Traversable has been removed in Scala 2.13, replaced with an Iterator based impl.

Would it be possible to publish artifacts for 2.13 at some point?